### PR TITLE
feat: Add an option to set the target attribute for anchor (<a>) tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ default_permission_group_id: 123
 default_user_segment_id: 456
 notify_subscribers: false
 contents_dir: path/to/contents
+enable_link_target_blank: false
 ```
 
 | Key                         | Required | Description                                              |
@@ -50,6 +51,7 @@ contents_dir: path/to/contents
 | default_user_segment_id     | false    | Specify the default user segment ID                      |
 | notify_subscribers          | false    | Specify whether to notify subscribers of the article     |
 | contents_dir                | false    | Specify the local directory path to manage articles      |
+| enable_link_target_blank    | false    | Specify if links open in a new tab (affected only push)  |
 
 ## Usage
 
@@ -204,6 +206,7 @@ warning messages
 ```
 
 - The conversion from HTML to Markdown uses [JohannesKaufmann/html-to-markdown](https://github.com/JohannesKaufmann/html-to-markdown), so fully consistent bidirectional conversion is not currently supported.
+- If `enable_link_target_blank` is set to `true`, the `target="_blank"　rel="noopener noreferrer"` attribute will be added to all anchor (<a>) tags.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ warning messages
 ```
 
 - The conversion from HTML to Markdown uses [JohannesKaufmann/html-to-markdown](https://github.com/JohannesKaufmann/html-to-markdown), so fully consistent bidirectional conversion is not currently supported.
-- If `enable_link_target_blank` is set to `true`, the `target="_blank"　rel="noopener noreferrer"` attribute will be added to all anchor (<a>) tags.
+- If `enable_link_target_blank` is set to `true`, the `target="_blank" rel="noopener noreferrer"` attributes will be added to all anchor (<a>) tags.
 
 ## Contributing
 

--- a/internal/cli/cmdPull.go
+++ b/internal/cli/cmdPull.go
@@ -21,7 +21,7 @@ type CommandPull struct {
 
 func (c *CommandPull) AfterApply(g *Global) error {
 	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
-	c.converter = converter.NewConverter()
+	c.converter = converter.NewConverter(false)
 	return nil
 }
 

--- a/internal/cli/cmdPush.go
+++ b/internal/cli/cmdPush.go
@@ -21,7 +21,7 @@ type CommandPush struct {
 
 func (c *CommandPush) AfterApply(g *Global) error {
 	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
-	c.converter = converter.NewConverter()
+	c.converter = converter.NewConverter(g.Config.EnableLinkTargetBlank)
 	return nil
 }
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	DefailtUserSegmentID     *int   `yaml:"default_user_segment_id" description:"Default user segment ID"`
 	NotifySubscribers        bool   `yaml:"notify_subscribers" description:"Notify subscribers when creating or updating articles" default:"false"`
 	ContentsDir              string `yaml:"contents_dir" description:"Path to the contents directory" default:"."`
+	EnableLinkTargetBlank    bool   `yaml:"enable_link_target_blank" description:"This makes links open in a new tab" default:"false"`
 }
 
 func (c *Config) Validation() error {

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -140,7 +140,7 @@ type linkTargetTransformer struct{}
 var LinkTargetTransformer = &linkTargetTransformer{}
 
 func (t *linkTargetTransformer) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
-	ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+	_ = ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
 		if link, ok := node.(*ast.Link); ok && entering {
 			link.SetAttribute([]byte("target"), []byte("_blank"))
 			link.SetAttribute([]byte("rel"), []byte("noopener noreferrer"))

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -12,9 +12,12 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	fences "github.com/stefanfritsch/goldmark-fences"
 	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
 	renderer "github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
 type Converter interface {
@@ -27,7 +30,7 @@ type converterImpl struct {
 	html     *md.Converter
 }
 
-func NewConverter() Converter {
+func NewConverter(enableLinkTargetBlank bool) Converter {
 	markdown := goldmark.New(
 		goldmark.WithExtensions(
 			extension.Table,
@@ -41,6 +44,14 @@ func NewConverter() Converter {
 			renderer.WithUnsafe(),
 		),
 	)
+
+	if enableLinkTargetBlank {
+		markdown.Parser().AddOptions(
+			parser.WithASTTransformers(
+				util.Prioritized(LinkTargetTransformer, 100),
+			),
+		)
+	}
 
 	html := md.NewConverter("", true, &md.Options{EscapeMode: "disabled", CodeBlockStyle: "fenced"})
 	html.Use(plugin.Table())
@@ -122,4 +133,18 @@ func replacementHeadings(content string, selec *goquery.Selection, opt *md.Optio
 	}
 
 	return md.String(prefix + " " + content + "\n")
+}
+
+type linkTargetTransformer struct{}
+
+var LinkTargetTransformer = &linkTargetTransformer{}
+
+func (t *linkTargetTransformer) Transform(node *ast.Document, reader text.Reader, pc parser.Context) {
+	ast.Walk(node, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if link, ok := node.(*ast.Link); ok && entering {
+			link.SetAttribute([]byte("target"), []byte("_blank"))
+			link.SetAttribute([]byte("rel"), []byte("noopener noreferrer"))
+		}
+		return ast.WalkContinue, nil
+	})
 }

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -32,7 +32,7 @@ func TestConvertToHTML_Div(t *testing.T) {
 		},
 	}
 
-	c := NewConverter()
+	c := NewConverter(false)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualHTMLContent, _ := c.ConvertToHTML(tc.markdown)
@@ -86,7 +86,65 @@ func TestConvertToHTML_Headings(t *testing.T) {
 		},
 	}
 
-	c := NewConverter()
+	c := NewConverter(false)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualHTMLContent, _ := c.ConvertToHTML(tc.markdown)
+			if strings.Compare(tc.expected, actualHTMLContent) != 0 {
+				t.Errorf("expected %s, got %s", tc.expected, actualHTMLContent)
+			}
+		})
+	}
+}
+
+func TestConvertToHTML_Anchor(t *testing.T) {
+	testCases := []struct {
+		name     string
+		markdown string
+		expected string
+	}{
+		{
+			name:     "Non-Attributes",
+			markdown: "[Example](https://www.example.com/)",
+			expected: "<p><a href=\"https://www.example.com/\">Example</a></p>\n",
+		},
+		{
+			name:     "Title",
+			markdown: "[Example](https://www.example.com/ \"Title\")",
+			expected: "<p><a href=\"https://www.example.com/\" title=\"Title\">Example</a></p>\n",
+		},
+	}
+
+	c := NewConverter(false)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualHTMLContent, _ := c.ConvertToHTML(tc.markdown)
+			if strings.Compare(tc.expected, actualHTMLContent) != 0 {
+				t.Errorf("expected %s, got %s", tc.expected, actualHTMLContent)
+			}
+		})
+	}
+}
+
+func TestConvertToHTML_AnchorWithTargetBlank(t *testing.T) {
+	testCases := []struct {
+		name     string
+		markdown string
+		expected string
+	}{
+		{
+			name:     "Non-Attributes",
+			markdown: "[Example](https://www.example.com/)",
+			expected: "<p><a href=\"https://www.example.com/\" target=\"_blank\" rel=\"noopener noreferrer\">Example</a></p>\n",
+		},
+		{
+			name:     "Title",
+			markdown: "[Example](https://www.example.com/ \"Title\")",
+			expected: "<p><a href=\"https://www.example.com/\" title=\"Title\" target=\"_blank\" rel=\"noopener noreferrer\">Example</a></p>\n",
+		},
+	}
+
+	c := NewConverter(true)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualHTMLContent, _ := c.ConvertToHTML(tc.markdown)


### PR DESCRIPTION
This PR introduces a new configuration option, `enable_link_target_blank`.
When set to true, this option automatically adds `target="_blank"` and `rel="noopener noreferrer"` attributes to all `<a>` tags in the generated HTML.