### PR TITLE
build: upgrade GoReleaser configuration to v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,5 @@
 ---
+version: 2
 project_name: zgsync
 before:
   hooks:
@@ -23,10 +24,10 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     format_overrides:
       - goos: darwin
-        format: zip
+        formats: ['zip']
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
@@ -34,7 +35,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   use: github  # Use GitHub Releases release notes
   sort: asc
@@ -42,7 +43,7 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-brews:
+homebrew_casks:
   - repository:
       owner: tukaelu
       name: homebrew-tap


### PR DESCRIPTION
- Add version: 2 declaration
- Replace deprecated snapshot.name_template with version_template
- Update archives.format to formats array syntax
- Replace brews with homebrew_casks

Fixes deprecation warnings in GitHub Actions:
- snapshot.name_template deprecation
- archives.format deprecation
- archives.format_overrides.format deprecation
- brews being phased out in favor of homebrew_casks