### PR TITLE
feat(cli): add media subcommand for Guide Media API

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,7 @@ type cli struct {
 	Pull    CommandPull    `cmd:"pull" help:"Pull translations or articles from the remote."`
 	Empty   CommandEmpty   `cmd:"empty" help:"Creates an empty draft article remotely and saves it locally."`
 	Archive CommandArchive `cmd:"archive" help:"Archive an article on the remote."`
+	Media   CommandMedia   `cmd:"media" help:"Manage Guide Media images."`
 	Version CommandVersion `cmd:"version" help:"Show version."`
 }
 

--- a/internal/cli/cmdMedia.go
+++ b/internal/cli/cmdMedia.go
@@ -1,0 +1,397 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/tukaelu/zgsync/internal/zendesk"
+	"gopkg.in/yaml.v3"
+)
+
+const mediaMaxRetries = 3
+
+var allowedMediaMIMETypes = map[string]bool{
+	"image/png":  true,
+	"image/jpeg": true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+type CommandMedia struct {
+	Create MediaCreateCmd `cmd:"" help:"Upload an image and create a Guide Media."`
+	Update MediaUpdateCmd `cmd:"" help:"Replace an existing Guide Media."`
+	List   MediaListCmd   `cmd:"" help:"List uploaded Guide Media as a mapping."`
+	Delete MediaDeleteCmd `cmd:"" help:"Delete a Guide Media."`
+}
+
+type MediaCreateCmd struct {
+	DryRun bool           `name:"dry-run" help:"Dry run (no upload)."`
+	File   string         `arg:"" help:"Image file to upload." type:"existingfile"`
+	client zendesk.Client `kong:"-"`
+}
+
+func (c *MediaCreateCmd) AfterApply(g *Global) error {
+	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
+	return nil
+}
+
+func (c *MediaCreateCmd) Run() error {
+	f, info, err := openMediaFile(c.File)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	mimeType, err := detectMediaMIMEType(f)
+	if err != nil {
+		return err
+	}
+	if !allowedMediaMIMETypes[mimeType] {
+		return fmt.Errorf("unsupported file type: %s (allowed: image/png, image/jpeg, image/gif, image/webp)", mimeType)
+	}
+
+	nameForUpload, err := cwdRelative(c.File)
+	if err != nil {
+		return err
+	}
+
+	if c.DryRun {
+		fmt.Printf("[dry-run] Would upload %s (%s) as %q\n", c.File, formatBytes(info.Size()), nameForUpload)
+		return nil
+	}
+
+	fmt.Printf("Uploading %s...\n", c.File)
+
+	var media *zendesk.GuideMedia
+	err = withMediaRetry(mediaMaxRetries, func() error {
+		upload, err := c.client.CreateUploadURL(mimeType, info.Size())
+		if err != nil {
+			return err
+		}
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		if err := c.client.UploadFileBinary(upload.UploadURL, upload.Headers, f); err != nil {
+			return err
+		}
+		m, err := c.client.CreateGuideMedia(upload.AssetUploadID, nameForUpload)
+		if err != nil {
+			return err
+		}
+		media = m
+		return nil
+	})
+	if err != nil {
+		var exhausted *errRetriesExhausted
+		if errors.As(err, &exhausted) {
+			return fmt.Errorf("failed to create Guide Media (gave up after %d retries).\nPlease retry the command", mediaMaxRetries)
+		}
+		return err
+	}
+
+	fmt.Printf("  Guide Media ID:  %s\n", media.ID)
+	fmt.Printf("  URL:             %s\n", media.URL)
+	return nil
+}
+
+type MediaUpdateCmd struct {
+	MediaID string         `name:"media-id" required:"" help:"Guide Media ID to replace (ULID)."`
+	DryRun  bool           `name:"dry-run" help:"Dry run (no upload)."`
+	File    string         `arg:"" help:"Image file to upload." type:"existingfile"`
+	client  zendesk.Client `kong:"-"`
+}
+
+func (c *MediaUpdateCmd) AfterApply(g *Global) error {
+	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
+	return nil
+}
+
+func (c *MediaUpdateCmd) Run() error {
+	f, info, err := openMediaFile(c.File)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	mimeType, err := detectMediaMIMEType(f)
+	if err != nil {
+		return err
+	}
+	if !allowedMediaMIMETypes[mimeType] {
+		return fmt.Errorf("unsupported file type: %s (allowed: image/png, image/jpeg, image/gif, image/webp)", mimeType)
+	}
+
+	nameForUpload, err := cwdRelative(c.File)
+	if err != nil {
+		return err
+	}
+
+	if c.DryRun {
+		fmt.Printf("[dry-run] Would replace Guide Media %s with %s (%s)\n", c.MediaID, c.File, formatBytes(info.Size()))
+		return nil
+	}
+
+	fmt.Printf("Uploading %s...\n", c.File)
+
+	var media *zendesk.GuideMedia
+	err = withMediaRetry(mediaMaxRetries, func() error {
+		upload, err := c.client.CreateUploadURL(mimeType, info.Size())
+		if err != nil {
+			return err
+		}
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return err
+		}
+		if err := c.client.UploadFileBinary(upload.UploadURL, upload.Headers, f); err != nil {
+			return err
+		}
+		m, err := c.client.ReplaceGuideMedia(c.MediaID, upload.AssetUploadID, nameForUpload)
+		if err != nil {
+			return err
+		}
+		media = m
+		return nil
+	})
+	if err != nil {
+		var exhausted *errRetriesExhausted
+		if errors.As(err, &exhausted) {
+			return fmt.Errorf("failed to replace Guide Media (gave up after %d retries).\nPlease retry the command", mediaMaxRetries)
+		}
+		return err
+	}
+
+	fmt.Printf("  Guide Media ID:  %s\n", media.ID)
+	fmt.Printf("  URL:             %s\n", media.URL)
+	fmt.Printf("  Version:         %d\n", media.Version)
+	return nil
+}
+
+type MediaListCmd struct {
+	Output string         `name:"output" default:"table" enum:"table,yaml,markdown" help:"Output format (table, yaml, or markdown)."`
+	client zendesk.Client `kong:"-"`
+}
+
+func (c *MediaListCmd) AfterApply(g *Global) error {
+	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
+	return nil
+}
+
+func (c *MediaListCmd) Run() error {
+	medias, err := c.client.ListGuideMedias()
+	if err != nil {
+		return err
+	}
+	sort.Slice(medias, func(i, j int) bool { return medias[i].Name < medias[j].Name })
+
+	switch c.Output {
+	case "yaml":
+		return printMediaListYAML(os.Stdout, medias)
+	case "markdown":
+		return printMediaListMarkdown(os.Stdout, medias)
+	default:
+		return printMediaListTable(os.Stdout, medias)
+	}
+}
+
+type MediaDeleteCmd struct {
+	MediaID string         `name:"media-id" required:"" help:"Guide Media ID to delete (ULID)."`
+	DryRun  bool           `name:"dry-run" help:"Dry run (no deletion)."`
+	client  zendesk.Client `kong:"-"`
+}
+
+func (c *MediaDeleteCmd) AfterApply(g *Global) error {
+	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
+	return nil
+}
+
+func (c *MediaDeleteCmd) Run() error {
+	if c.DryRun {
+		fmt.Printf("[dry-run] Would delete Guide Media %s\n", c.MediaID)
+		return nil
+	}
+	fmt.Println("Warning: Deleting a Guide Media that is embedded in articles will break those images.")
+	fmt.Println("Deleting...")
+	fmt.Printf("  Guide Media ID:  %s\n", c.MediaID)
+	if err := c.client.DeleteGuideMedia(c.MediaID); err != nil {
+		return err
+	}
+	fmt.Println("  Deleted.")
+	return nil
+}
+
+// errRetriesExhausted indicates that withMediaRetry gave up after exhausting
+// the retry budget. The wrapped error is the last failure encountered.
+type errRetriesExhausted struct {
+	retries int
+	lastErr error
+}
+
+func (e *errRetriesExhausted) Error() string {
+	return fmt.Sprintf("gave up after %d retries: %v", e.retries, e.lastErr)
+}
+
+func (e *errRetriesExhausted) Unwrap() error { return e.lastErr }
+
+// withMediaRetry runs fn, retrying on retryable errors up to maxRetries times.
+// Total invocations are at most maxRetries+1. Non-retryable errors return immediately.
+func withMediaRetry(maxRetries int, fn func() error) error {
+	var lastErr error
+	for i := 0; i <= maxRetries; i++ {
+		if lastErr = fn(); lastErr == nil {
+			return nil
+		}
+		if !isRetryable(lastErr) {
+			return lastErr
+		}
+	}
+	return &errRetriesExhausted{retries: maxRetries, lastErr: lastErr}
+}
+
+func isRetryable(err error) bool {
+	var httpErr *zendesk.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode >= 500
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout()
+	}
+	return false
+}
+
+func openMediaFile(path string) (*os.File, os.FileInfo, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, nil, err
+	}
+	return f, info, nil
+}
+
+// detectMediaMIMEType uses http.DetectContentType on the first 512 bytes,
+// falling back to the file extension when detection fails.
+// The file is rewound to the start before returning.
+func detectMediaMIMEType(f *os.File) (string, error) {
+	buf := make([]byte, 512)
+	n, err := f.Read(buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return "", err
+	}
+	mimeType := http.DetectContentType(buf[:n])
+	if !strings.HasPrefix(mimeType, "image/") {
+		switch strings.ToLower(filepath.Ext(f.Name())) {
+		case ".png":
+			return "image/png", nil
+		case ".jpg", ".jpeg":
+			return "image/jpeg", nil
+		case ".gif":
+			return "image/gif", nil
+		case ".webp":
+			return "image/webp", nil
+		}
+	}
+	return mimeType, nil
+}
+
+// cwdRelative returns the path relative to the current working directory.
+// If the file lives outside the CWD subtree (e.g. "../foo" or an absolute
+// path elsewhere), it falls back to the base name to keep the Guide Media
+// name field tidy.
+func cwdRelative(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(cwd, abs)
+	if err != nil {
+		return "", err
+	}
+	if !filepath.IsLocal(rel) {
+		return filepath.Base(path), nil
+	}
+	return rel, nil
+}
+
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+func printMediaListTable(w io.Writer, medias []*zendesk.GuideMedia) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "LOCAL PATH\tGUIDE MEDIA ID\tURL\tVERSION"); err != nil {
+		return err
+	}
+	for _, m := range medias {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%d\n", m.Name, m.ID, m.URL, m.Version); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func printMediaListYAML(w io.Writer, medias []*zendesk.GuideMedia) error {
+	root := &yaml.Node{Kind: yaml.MappingNode}
+	for _, m := range medias {
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: m.Name},
+			&yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "media_id"},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: m.ID},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "url"},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: m.URL},
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "version"},
+				{Kind: yaml.ScalarNode, Tag: "!!int", Value: strconv.Itoa(m.Version)},
+			}},
+		)
+	}
+	out, err := yaml.Marshal(root)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(out)
+	return err
+}
+
+func printMediaListMarkdown(w io.Writer, medias []*zendesk.GuideMedia) error {
+	if _, err := fmt.Fprintln(w, "| LOCAL PATH | GUIDE MEDIA ID | URL | VERSION |"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "|---|---|---|---|"); err != nil {
+		return err
+	}
+	for _, m := range medias {
+		if _, err := fmt.Fprintf(w, "| %s | %s | %s | %d |\n", m.Name, m.ID, m.URL, m.Version); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/cli/cmdMedia_test.go
+++ b/internal/cli/cmdMedia_test.go
@@ -178,6 +178,9 @@ func TestDetectMediaMIMEType(t *testing.T) {
 		// Fallback paths: bytes don't match any image format, but the extension does.
 		{"webp fallback by extension", ".webp", []byte("not really a webp file"), "image/webp"},
 		{"png fallback by extension", ".png", []byte("plain text"), "image/png"},
+		{"jpeg fallback by .jpg ext", ".jpg", []byte("not a jpeg"), "image/jpeg"},
+		{"jpeg fallback by .jpeg ext", ".jpeg", []byte("not a jpeg"), "image/jpeg"},
+		{"gif fallback by extension", ".gif", []byte("not a gif"), "image/gif"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -875,4 +878,97 @@ func TestMediaDeleteCmd_Run_PropagatesError(t *testing.T) {
 	if !errors.As(err, &httpErr) || httpErr.StatusCode != 404 {
 		t.Errorf("err = %v, want 404 *HTTPError", err)
 	}
+}
+
+// ------------------- AfterApply -------------------
+
+// All four media subcommands wire up the Zendesk client identically — verify
+// that each AfterApply produces a client whose baseURL reflects the configured
+// subdomain.
+func TestMediaCmds_AfterApply(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(g *Global) (zendesk.Client, error)
+	}{
+		{
+			"create",
+			func(g *Global) (zendesk.Client, error) {
+				c := &MediaCreateCmd{}
+				err := c.AfterApply(g)
+				return c.client, err
+			},
+		},
+		{
+			"update",
+			func(g *Global) (zendesk.Client, error) {
+				c := &MediaUpdateCmd{}
+				err := c.AfterApply(g)
+				return c.client, err
+			},
+		},
+		{
+			"list",
+			func(g *Global) (zendesk.Client, error) {
+				c := &MediaListCmd{}
+				err := c.AfterApply(g)
+				return c.client, err
+			},
+		},
+		{
+			"delete",
+			func(g *Global) (zendesk.Client, error) {
+				c := &MediaDeleteCmd{}
+				err := c.AfterApply(g)
+				return c.client, err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			global := &Global{
+				Config: Config{
+					Subdomain: "mycompany",
+					Email:     "test@example.com",
+					Token:     "token",
+				},
+			}
+			client, err := tt.run(global)
+			if err != nil {
+				t.Fatalf("AfterApply: %v", err)
+			}
+			if client == nil {
+				t.Fatal("client was not initialized")
+			}
+			if baseURL := zendesk.ClientBaseURL(client); !strings.Contains(baseURL, "mycompany") {
+				t.Errorf("baseURL %q does not contain subdomain %q", baseURL, "mycompany")
+			}
+		})
+	}
+}
+
+// ------------------- printMediaListMarkdown writer-error paths -------------------
+
+// Drive each of the three Fprintln/Fprintf error returns by failing on the
+// 1st (header), 2nd (separator), and 3rd (row) write respectively.
+func TestPrintMediaListMarkdown_WriterError(t *testing.T) {
+	t.Parallel()
+	for n := 0; n < 3; n++ {
+		w := &failAfterNWriter{n: n}
+		if err := printMediaListMarkdown(w, sampleMedias()); err == nil {
+			t.Errorf("n=%d: expected error, got nil", n)
+		}
+	}
+}
+
+type failAfterNWriter struct {
+	n     int
+	calls int
+}
+
+func (f *failAfterNWriter) Write(p []byte) (int, error) {
+	f.calls++
+	if f.calls > f.n {
+		return 0, io.ErrShortWrite
+	}
+	return len(p), nil
 }

--- a/internal/cli/cmdMedia_test.go
+++ b/internal/cli/cmdMedia_test.go
@@ -1,0 +1,878 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/tukaelu/zgsync/internal/cli/testhelper"
+	"github.com/tukaelu/zgsync/internal/zendesk"
+	"gopkg.in/yaml.v3"
+)
+
+// magic bytes for image format detection
+var (
+	pngMagic = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 13}
+	jpegMagic = []byte{0xFF, 0xD8, 0xFF, 0xE0, 0, 0x10, 'J', 'F', 'I', 'F'}
+	gif89aMagic = []byte("GIF89a")
+	// WebP requires "RIFF????WEBP" — 12 bytes minimum so http.DetectContentType matches.
+	webpMagic = append([]byte("RIFF\x00\x00\x00\x00WEBPVP8 "), bytes.Repeat([]byte{0}, 4)...)
+)
+
+// fakeNetError implements net.Error so we can drive isRetryable's timeout branch.
+type fakeNetError struct {
+	msg     string
+	timeout bool
+}
+
+func (e *fakeNetError) Error() string   { return e.msg }
+func (e *fakeNetError) Timeout() bool   { return e.timeout }
+func (e *fakeNetError) Temporary() bool { return false }
+
+func TestWithMediaRetry_SucceedsImmediately(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := withMediaRetry(3, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+}
+
+func TestWithMediaRetry_SucceedsAfterRetry(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := withMediaRetry(3, func() error {
+		calls++
+		if calls < 3 {
+			return &zendesk.HTTPError{StatusCode: 503}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil after retry success, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3", calls)
+	}
+}
+
+func TestWithMediaRetry_NonRetryableExitsImmediately(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := withMediaRetry(3, func() error {
+		calls++
+		return &zendesk.HTTPError{StatusCode: 400}
+	})
+
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (non-retryable must not retry)", calls)
+	}
+	var httpErr *zendesk.HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *zendesk.HTTPError, got %T (%v)", err, err)
+	}
+	if httpErr.StatusCode != 400 {
+		t.Errorf("StatusCode = %d, want 400 (must surface the original status)", httpErr.StatusCode)
+	}
+	var exhausted *errRetriesExhausted
+	if errors.As(err, &exhausted) {
+		t.Errorf("non-retryable error must not be wrapped in errRetriesExhausted")
+	}
+}
+
+func TestWithMediaRetry_Exhaustion(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	err := withMediaRetry(3, func() error {
+		calls++
+		return &zendesk.HTTPError{StatusCode: 503}
+	})
+
+	// 1 initial + 3 retries = 4 invocations.
+	if calls != 4 {
+		t.Errorf("calls = %d, want 4 (initial + 3 retries)", calls)
+	}
+	var exhausted *errRetriesExhausted
+	if !errors.As(err, &exhausted) {
+		t.Fatalf("expected *errRetriesExhausted, got %T (%v)", err, err)
+	}
+	if exhausted.retries != 3 {
+		t.Errorf("retries = %d, want 3", exhausted.retries)
+	}
+	// Unwrap should expose the last underlying error.
+	var httpErr *zendesk.HTTPError
+	if !errors.As(exhausted, &httpErr) || httpErr.StatusCode != 503 {
+		t.Errorf("Unwrap chain missing 503: %v", exhausted)
+	}
+}
+
+func TestErrRetriesExhausted_ErrorMessage(t *testing.T) {
+	t.Parallel()
+	e := &errRetriesExhausted{retries: 3, lastErr: errors.New("boom")}
+	if !strings.Contains(e.Error(), "gave up after 3 retries") {
+		t.Errorf("Error() = %q, missing retry count phrase", e.Error())
+	}
+	if !strings.Contains(e.Error(), "boom") {
+		t.Errorf("Error() = %q, missing wrapped cause", e.Error())
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"500", &zendesk.HTTPError{StatusCode: 500}, true},
+		{"502", &zendesk.HTTPError{StatusCode: 502}, true},
+		{"503", &zendesk.HTTPError{StatusCode: 503}, true},
+		{"599", &zendesk.HTTPError{StatusCode: 599}, true},
+		{"400", &zendesk.HTTPError{StatusCode: 400}, false},
+		{"401", &zendesk.HTTPError{StatusCode: 401}, false},
+		{"404", &zendesk.HTTPError{StatusCode: 404}, false},
+		{"422", &zendesk.HTTPError{StatusCode: 422}, false},
+		{"499", &zendesk.HTTPError{StatusCode: 499}, false},
+		{"wrapped 500 unwraps", fmt.Errorf("step 1: %w", &zendesk.HTTPError{StatusCode: 500}), true},
+		{"wrapped 400 stays non-retryable", fmt.Errorf("step 1: %w", &zendesk.HTTPError{StatusCode: 400}), false},
+		{"net.Error timeout=true", &fakeNetError{msg: "i/o timeout", timeout: true}, true},
+		{"net.Error timeout=false", &fakeNetError{msg: "connection refused", timeout: false}, false},
+		{"plain error", errors.New("boom"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isRetryable(tt.err); got != tt.want {
+				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectMediaMIMEType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ext      string
+		contents []byte
+		want     string
+	}{
+		{"png magic", ".png", pngMagic, "image/png"},
+		{"jpeg magic", ".jpg", jpegMagic, "image/jpeg"},
+		{"gif magic", ".gif", gif89aMagic, "image/gif"},
+		{"webp magic", ".webp", webpMagic, "image/webp"},
+		// Fallback paths: bytes don't match any image format, but the extension does.
+		{"webp fallback by extension", ".webp", []byte("not really a webp file"), "image/webp"},
+		{"png fallback by extension", ".png", []byte("plain text"), "image/png"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "sample"+tt.ext)
+			if err := os.WriteFile(path, tt.contents, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			f, err := os.Open(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = f.Close() })
+
+			got, err := detectMediaMIMEType(f)
+			if err != nil {
+				t.Fatalf("detectMediaMIMEType: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+
+			// File must be rewound so the caller can read from byte 0.
+			pos, err := f.Seek(0, io.SeekCurrent)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if pos != 0 {
+				t.Errorf("file position after detection = %d, want 0", pos)
+			}
+		})
+	}
+}
+
+// detectMediaMIMEType must NOT default to image/* for non-image files even
+// when the extension is unknown — caller relies on the allowlist check.
+func TestDetectMediaMIMEType_UnknownNonImageReturnsAsIs(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "sample.txt")
+	if err := os.WriteFile(path, []byte("just some plain text content here"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	got, err := detectMediaMIMEType(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.HasPrefix(got, "image/") {
+		t.Errorf("plain text should not be detected as image/*, got %q", got)
+	}
+}
+
+func TestCwdRelative(t *testing.T) {
+	tempDir := t.TempDir()
+	subDir := filepath.Join(tempDir, "images")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// EvalSymlinks because t.TempDir on macOS resolves /var → /private/var.
+	resolvedTempDir, err := filepath.EvalSymlinks(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(resolvedTempDir)
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"relative path in subdir", "images/foo.png", "images/foo.png"},
+		{"absolute path inside cwd", filepath.Join(resolvedTempDir, "images", "foo.png"), "images/foo.png"},
+		{"file in same dir", "foo.png", "foo.png"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := cwdRelative(tt.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Files outside the CWD subtree must fall back to the base name so the
+// Guide Media `name` field doesn't contain `..` segments.
+func TestCwdRelative_OutsideCwdFallsBackToBaseName(t *testing.T) {
+	cwd := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "remote.png")
+
+	resolvedCwd, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(resolvedCwd)
+
+	got, err := cwdRelative(outsidePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "remote.png" {
+		t.Errorf("got %q, want %q (base-name fallback)", got, "remote.png")
+	}
+
+	// Same with a relative ".." path.
+	got2, err := cwdRelative("../something/else.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got2 != "else.png" {
+		t.Errorf("got %q, want %q (base-name fallback for ../)", got2, "else.png")
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		// 45.2 KB matches the design example: 46285 / 1024 ≈ 45.20.
+		{46285, "45.2 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{1024*1024 + 512*1024, "1.5 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.in), func(t *testing.T) {
+			t.Parallel()
+			if got := formatBytes(tt.in); got != tt.want {
+				t.Errorf("formatBytes(%d) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func sampleMedias() []*zendesk.GuideMedia {
+	return []*zendesk.GuideMedia{
+		{ID: "01ABC", Name: "images/a.png", URL: "https://hc/a", Version: 1},
+		{ID: "01DEF", Name: "images/b.png", URL: "https://hc/b", Version: 2},
+	}
+}
+
+func TestPrintMediaListTable(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := printMediaListTable(&buf, sampleMedias()); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"LOCAL PATH", "GUIDE MEDIA ID", "URL", "VERSION",
+		"images/a.png", "01ABC", "https://hc/a",
+		"images/b.png", "01DEF", "https://hc/b",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\n--- got ---\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintMediaListTable_Empty(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := printMediaListTable(&buf, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "LOCAL PATH") {
+		t.Errorf("empty list should still print header, got %q", buf.String())
+	}
+}
+
+func TestPrintMediaListYAML_Empty(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := printMediaListYAML(&buf, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Output must be valid YAML that round-trips to an empty map; we don't
+	// pin the exact representation ("{}" vs blank) but we forbid garbage.
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("yaml output is not valid: %q -> %v", buf.String(), err)
+	}
+	if len(parsed) != 0 {
+		t.Errorf("empty input produced non-empty map: %v", parsed)
+	}
+}
+
+func TestPrintMediaListMarkdown_Empty(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := printMediaListMarkdown(&buf, nil); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (header + sep) for empty list, got %d:\n%s", len(lines), buf.String())
+	}
+	if !strings.HasPrefix(lines[0], "| LOCAL PATH ") {
+		t.Errorf("header line = %q", lines[0])
+	}
+	if lines[1] != "|---|---|---|---|" {
+		t.Errorf("separator line = %q", lines[1])
+	}
+}
+
+func TestPrintMediaListYAML(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := printMediaListYAML(&buf, sampleMedias()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Round-trip through YAML to verify structure and types.
+	var parsed map[string]struct {
+		MediaID string `yaml:"media_id"`
+		URL     string `yaml:"url"`
+		Version int    `yaml:"version"`
+	}
+	if err := yaml.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("yaml.Unmarshal(%q): %v", buf.String(), err)
+	}
+	if got := parsed["images/a.png"]; got.MediaID != "01ABC" || got.URL != "https://hc/a" || got.Version != 1 {
+		t.Errorf("entry a = %+v", got)
+	}
+	if got := parsed["images/b.png"]; got.MediaID != "01DEF" || got.URL != "https://hc/b" || got.Version != 2 {
+		t.Errorf("entry b = %+v", got)
+	}
+}
+
+func TestPrintMediaListMarkdown(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := printMediaListMarkdown(&buf, sampleMedias()); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("got %d lines, want 4 (header + sep + 2 rows): %q", len(lines), buf.String())
+	}
+	if !strings.HasPrefix(lines[0], "| LOCAL PATH ") {
+		t.Errorf("header line = %q", lines[0])
+	}
+	if lines[1] != "|---|---|---|---|" {
+		t.Errorf("separator line = %q", lines[1])
+	}
+	if !strings.Contains(lines[2], "01ABC") || !strings.Contains(lines[3], "01DEF") {
+		t.Errorf("rows missing IDs:\n%s", buf.String())
+	}
+}
+
+// ------------------- MediaCreateCmd.Run -------------------
+
+func writeMediaFile(t *testing.T, name string, contents []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestMediaCreateCmd_Run_DryRunDoesNotCallClient(t *testing.T) {
+	path := writeMediaFile(t, "test.png", pngMagic)
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(string, int64) (*zendesk.UploadURLResponse, error) {
+			t.Fatal("CreateUploadURL must not be called in dry-run")
+			return nil, nil
+		},
+		UploadFileBinaryFunc: func(string, map[string]string, io.Reader) error {
+			t.Fatal("UploadFileBinary must not be called in dry-run")
+			return nil
+		},
+		CreateGuideMediaFunc: func(string, string) (*zendesk.GuideMedia, error) {
+			t.Fatal("CreateGuideMedia must not be called in dry-run")
+			return nil, nil
+		},
+	}
+	cmd := MediaCreateCmd{File: path, DryRun: true, client: mock}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("dry-run Run: %v", err)
+	}
+}
+
+func TestMediaCreateCmd_Run_Success(t *testing.T) {
+	path := writeMediaFile(t, "screenshot.png", pngMagic)
+
+	var (
+		callOrder        []string
+		gotContentType   string
+		gotFileSize      int64
+		gotUploadURL     string
+		gotHeaders       map[string]string
+		gotUploadedBody  []byte
+		gotAssetUploadID string
+		gotFilename      string
+	)
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(ct string, sz int64) (*zendesk.UploadURLResponse, error) {
+			callOrder = append(callOrder, "CreateUploadURL")
+			gotContentType = ct
+			gotFileSize = sz
+			return &zendesk.UploadURLResponse{
+				UploadURL:     "https://s3.example/upload?sig=abc",
+				AssetUploadID: "01ASSET",
+				Headers:       map[string]string{"Content-Type": "image/png", "X-Amz-Date": "20260101T000000Z"},
+			}, nil
+		},
+		UploadFileBinaryFunc: func(url string, headers map[string]string, body io.Reader) error {
+			callOrder = append(callOrder, "UploadFileBinary")
+			gotUploadURL = url
+			gotHeaders = headers
+			gotUploadedBody, _ = io.ReadAll(body)
+			return nil
+		},
+		CreateGuideMediaFunc: func(assetID, filename string) (*zendesk.GuideMedia, error) {
+			callOrder = append(callOrder, "CreateGuideMedia")
+			gotAssetUploadID = assetID
+			gotFilename = filename
+			return &zendesk.GuideMedia{ID: "01HM", URL: "https://hc/abc", Version: 1}, nil
+		},
+	}
+
+	cmd := MediaCreateCmd{File: path, client: mock}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	wantOrder := []string{"CreateUploadURL", "UploadFileBinary", "CreateGuideMedia"}
+	if !reflect.DeepEqual(callOrder, wantOrder) {
+		t.Errorf("call order = %v, want %v", callOrder, wantOrder)
+	}
+	if gotContentType != "image/png" {
+		t.Errorf("CreateUploadURL contentType = %q", gotContentType)
+	}
+	if gotFileSize != int64(len(pngMagic)) {
+		t.Errorf("CreateUploadURL fileSize = %d, want %d", gotFileSize, len(pngMagic))
+	}
+	if gotUploadURL != "https://s3.example/upload?sig=abc" {
+		t.Errorf("UploadFileBinary uploadURL = %q", gotUploadURL)
+	}
+	// Headers from upload_url must be forwarded verbatim.
+	if gotHeaders["X-Amz-Date"] != "20260101T000000Z" {
+		t.Errorf("X-Amz-Date header lost: %v", gotHeaders)
+	}
+	// Body sent to S3 must match the file contents.
+	if !bytes.Equal(gotUploadedBody, pngMagic) {
+		t.Errorf("uploaded body mismatch\n got: %q\nwant: %q", gotUploadedBody, pngMagic)
+	}
+	if gotAssetUploadID != "01ASSET" {
+		t.Errorf("CreateGuideMedia assetUploadID = %q", gotAssetUploadID)
+	}
+	// File is in t.TempDir() outside the test's cwd, so cwdRelative falls back to base name.
+	if gotFilename != "screenshot.png" {
+		t.Errorf("CreateGuideMedia filename = %q, want %q", gotFilename, "screenshot.png")
+	}
+}
+
+func TestMediaCreateCmd_Run_UnsupportedMIMEType(t *testing.T) {
+	path := writeMediaFile(t, "doc.txt", []byte("plain text content not an image"))
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(string, int64) (*zendesk.UploadURLResponse, error) {
+			t.Fatal("client must not be called for unsupported MIME types")
+			return nil, nil
+		},
+	}
+	cmd := MediaCreateCmd{File: path, client: mock}
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected error for unsupported MIME type, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported file type") {
+		t.Errorf("err = %q, want phrase 'unsupported file type'", err.Error())
+	}
+}
+
+func TestMediaCreateCmd_Run_RetryExhaustionMessage(t *testing.T) {
+	path := writeMediaFile(t, "test.png", pngMagic)
+
+	calls := 0
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(string, int64) (*zendesk.UploadURLResponse, error) {
+			calls++
+			return nil, &zendesk.HTTPError{StatusCode: 503}
+		},
+	}
+	cmd := MediaCreateCmd{File: path, client: mock}
+	err := cmd.Run()
+
+	if calls != mediaMaxRetries+1 {
+		t.Errorf("CreateUploadURL calls = %d, want %d", calls, mediaMaxRetries+1)
+	}
+	if err == nil {
+		t.Fatal("expected error from retry exhaustion, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create Guide Media") {
+		t.Errorf("err = %q, want 'failed to create Guide Media'", err.Error())
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("gave up after %d retries", mediaMaxRetries)) {
+		t.Errorf("err = %q, missing retry count phrase", err.Error())
+	}
+	if !strings.Contains(err.Error(), "Please retry the command") {
+		t.Errorf("err = %q, missing retry hint", err.Error())
+	}
+}
+
+// Critical regression test: when Step 2 (UploadFileBinary) fails transiently,
+// the retry must restart from Step 1 AND rewind the file so the second upload
+// sends the full file content again. Without f.Seek(0) before UploadFileBinary,
+// the second iteration would send empty bytes (file at EOF after first read).
+func TestMediaCreateCmd_Run_RetriesAndSucceeds(t *testing.T) {
+	path := writeMediaFile(t, "test.png", pngMagic)
+
+	var (
+		createUploadURLCalls  int
+		uploadFileBinaryCalls int
+		createGuideMediaCalls int
+		secondUploadBody      []byte
+		assetIDsSeenByCreate  []string
+	)
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(ct string, sz int64) (*zendesk.UploadURLResponse, error) {
+			createUploadURLCalls++
+			// Each retry should produce a fresh asset_upload_id, mirroring real Zendesk behavior.
+			return &zendesk.UploadURLResponse{
+				UploadURL:     "https://upload.example/x",
+				AssetUploadID: fmt.Sprintf("asset-%d", createUploadURLCalls),
+			}, nil
+		},
+		UploadFileBinaryFunc: func(_ string, _ map[string]string, body io.Reader) error {
+			uploadFileBinaryCalls++
+			// Drain the body to advance the file's read position — simulates a real upload that
+			// reads the whole file before failing.
+			data, _ := io.ReadAll(body)
+			if uploadFileBinaryCalls == 1 {
+				return &zendesk.HTTPError{StatusCode: 503}
+			}
+			secondUploadBody = data
+			return nil
+		},
+		CreateGuideMediaFunc: func(assetID, _ string) (*zendesk.GuideMedia, error) {
+			createGuideMediaCalls++
+			assetIDsSeenByCreate = append(assetIDsSeenByCreate, assetID)
+			return &zendesk.GuideMedia{ID: "01HM", URL: "https://hc/x", Version: 1}, nil
+		},
+	}
+
+	cmd := MediaCreateCmd{File: path, client: mock}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run failed unexpectedly: %v", err)
+	}
+
+	if createUploadURLCalls != 2 {
+		t.Errorf("CreateUploadURL calls = %d, want 2 (retry must restart from Step 1)", createUploadURLCalls)
+	}
+	if uploadFileBinaryCalls != 2 {
+		t.Errorf("UploadFileBinary calls = %d, want 2", uploadFileBinaryCalls)
+	}
+	if createGuideMediaCalls != 1 {
+		t.Errorf("CreateGuideMedia calls = %d, want 1 (Step 3 must run only after a successful upload)", createGuideMediaCalls)
+	}
+
+	// The pivotal assertion: on retry, the file MUST be rewound. Without Seek(0),
+	// the second UploadFileBinary call would receive an empty body.
+	if !bytes.Equal(secondUploadBody, pngMagic) {
+		t.Errorf("second upload body = %q (len=%d), want full file %q (len=%d) — file was not rewound between retries",
+			secondUploadBody, len(secondUploadBody), pngMagic, len(pngMagic))
+	}
+
+	// And Step 3 must use the FRESH asset_upload_id from the retry, not the stale one.
+	if len(assetIDsSeenByCreate) != 1 || assetIDsSeenByCreate[0] != "asset-2" {
+		t.Errorf("CreateGuideMedia received assetIDs %v, want [asset-2] (must use the retried Step 1 result)", assetIDsSeenByCreate)
+	}
+}
+
+func TestMediaCreateCmd_Run_NonRetryableErrorPropagatesAsIs(t *testing.T) {
+	path := writeMediaFile(t, "test.png", pngMagic)
+
+	calls := 0
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(string, int64) (*zendesk.UploadURLResponse, error) {
+			calls++
+			return nil, &zendesk.HTTPError{StatusCode: 401}
+		},
+	}
+	cmd := MediaCreateCmd{File: path, client: mock}
+	err := cmd.Run()
+
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (non-retryable must not retry)", calls)
+	}
+	var httpErr *zendesk.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != 401 {
+		t.Errorf("expected 401 *HTTPError, got %v", err)
+	}
+}
+
+// ------------------- MediaUpdateCmd.Run -------------------
+
+func TestMediaUpdateCmd_Run_DryRunDoesNotCallClient(t *testing.T) {
+	path := writeMediaFile(t, "test.png", pngMagic)
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(string, int64) (*zendesk.UploadURLResponse, error) {
+			t.Fatal("must not call client in dry-run")
+			return nil, nil
+		},
+	}
+	cmd := MediaUpdateCmd{File: path, MediaID: "01HM", DryRun: true, client: mock}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestMediaUpdateCmd_Run_CallsReplaceWithCorrectArgs(t *testing.T) {
+	path := writeMediaFile(t, "v2.png", pngMagic)
+
+	var (
+		callOrder       []string
+		gotMediaID      string
+		gotAssetID      string
+		gotFilename     string
+		createCalled    bool
+	)
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(string, int64) (*zendesk.UploadURLResponse, error) {
+			callOrder = append(callOrder, "CreateUploadURL")
+			return &zendesk.UploadURLResponse{
+				UploadURL:     "https://s3/x",
+				AssetUploadID: "01NEWASSET",
+			}, nil
+		},
+		UploadFileBinaryFunc: func(string, map[string]string, io.Reader) error {
+			callOrder = append(callOrder, "UploadFileBinary")
+			return nil
+		},
+		ReplaceGuideMediaFunc: func(id, assetID, filename string) (*zendesk.GuideMedia, error) {
+			callOrder = append(callOrder, "ReplaceGuideMedia")
+			gotMediaID = id
+			gotAssetID = assetID
+			gotFilename = filename
+			return &zendesk.GuideMedia{ID: id, URL: "https://hc/x", Version: 2}, nil
+		},
+		CreateGuideMediaFunc: func(string, string) (*zendesk.GuideMedia, error) {
+			createCalled = true
+			return nil, nil
+		},
+	}
+
+	cmd := MediaUpdateCmd{File: path, MediaID: "01TARGET", client: mock}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if createCalled {
+		t.Errorf("update must call ReplaceGuideMedia, not CreateGuideMedia")
+	}
+	wantOrder := []string{"CreateUploadURL", "UploadFileBinary", "ReplaceGuideMedia"}
+	if !reflect.DeepEqual(callOrder, wantOrder) {
+		t.Errorf("call order = %v, want %v", callOrder, wantOrder)
+	}
+	if gotMediaID != "01TARGET" {
+		t.Errorf("ReplaceGuideMedia id = %q, want %q", gotMediaID, "01TARGET")
+	}
+	if gotAssetID != "01NEWASSET" {
+		t.Errorf("ReplaceGuideMedia assetID = %q", gotAssetID)
+	}
+	if gotFilename != "v2.png" {
+		t.Errorf("ReplaceGuideMedia filename = %q, want %q", gotFilename, "v2.png")
+	}
+}
+
+func TestMediaUpdateCmd_Run_RetryExhaustionMessage(t *testing.T) {
+	path := writeMediaFile(t, "test.png", pngMagic)
+	mock := &testhelper.MockZendeskClient{
+		CreateUploadURLFunc: func(string, int64) (*zendesk.UploadURLResponse, error) {
+			return nil, &zendesk.HTTPError{StatusCode: 503}
+		},
+	}
+	cmd := MediaUpdateCmd{File: path, MediaID: "01HM", client: mock}
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to replace Guide Media") {
+		t.Errorf("err = %q, want 'failed to replace Guide Media' (not 'create')", err.Error())
+	}
+}
+
+// ------------------- MediaListCmd.Run -------------------
+
+func TestMediaListCmd_Run_TableFormat(t *testing.T) {
+	t.Parallel()
+	mock := &testhelper.MockZendeskClient{
+		ListGuideMediasFunc: func() ([]*zendesk.GuideMedia, error) {
+			return sampleMedias(), nil
+		},
+	}
+	cmd := MediaListCmd{Output: "table", client: mock}
+	// Output goes to stdout; we already test the formatter directly. Here we
+	// just ensure Run does not error when the API returns rows.
+	if err := cmd.Run(); err != nil {
+		t.Errorf("Run: %v", err)
+	}
+}
+
+func TestMediaListCmd_Run_PropagatesAPIError(t *testing.T) {
+	t.Parallel()
+	want := errors.New("api unreachable")
+	mock := &testhelper.MockZendeskClient{
+		ListGuideMediasFunc: func() ([]*zendesk.GuideMedia, error) {
+			return nil, want
+		},
+	}
+	cmd := MediaListCmd{Output: "table", client: mock}
+	err := cmd.Run()
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want %v", err, want)
+	}
+}
+
+func TestMediaListCmd_Run_AcceptsAllFormats(t *testing.T) {
+	mock := &testhelper.MockZendeskClient{
+		ListGuideMediasFunc: func() ([]*zendesk.GuideMedia, error) {
+			return sampleMedias(), nil
+		},
+	}
+	for _, format := range []string{"table", "yaml", "markdown", ""} {
+		cmd := MediaListCmd{Output: format, client: mock}
+		if err := cmd.Run(); err != nil {
+			t.Errorf("format %q: %v", format, err)
+		}
+	}
+}
+
+// ------------------- MediaDeleteCmd.Run -------------------
+
+func TestMediaDeleteCmd_Run_DryRunDoesNotCallClient(t *testing.T) {
+	t.Parallel()
+	mock := &testhelper.MockZendeskClient{
+		DeleteGuideMediaFunc: func(string) error {
+			t.Fatal("must not call delete in dry-run")
+			return nil
+		},
+	}
+	cmd := MediaDeleteCmd{MediaID: "01HM", DryRun: true, client: mock}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
+func TestMediaDeleteCmd_Run_Success(t *testing.T) {
+	t.Parallel()
+	var gotID string
+	mock := &testhelper.MockZendeskClient{
+		DeleteGuideMediaFunc: func(id string) error {
+			gotID = id
+			return nil
+		},
+	}
+	cmd := MediaDeleteCmd{MediaID: "01HM", client: mock}
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if gotID != "01HM" {
+		t.Errorf("DeleteGuideMedia id = %q", gotID)
+	}
+}
+
+func TestMediaDeleteCmd_Run_PropagatesError(t *testing.T) {
+	t.Parallel()
+	want := &zendesk.HTTPError{StatusCode: 404}
+	mock := &testhelper.MockZendeskClient{
+		DeleteGuideMediaFunc: func(string) error { return want },
+	}
+	cmd := MediaDeleteCmd{MediaID: "01HM", client: mock}
+	err := cmd.Run()
+	var httpErr *zendesk.HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != 404 {
+		t.Errorf("err = %v, want 404 *HTTPError", err)
+	}
+}

--- a/internal/cli/testhelper/mock.go
+++ b/internal/cli/testhelper/mock.go
@@ -2,6 +2,9 @@ package testhelper
 
 import (
 	"encoding/json"
+	"io"
+
+	"github.com/tukaelu/zgsync/internal/zendesk"
 )
 
 // MockZendeskClient is a centralized mock implementation of zendesk.Client
@@ -13,6 +16,12 @@ type MockZendeskClient struct {
 	CreateTranslationFunc func(articleID int, payload string) (string, error)
 	UpdateTranslationFunc func(articleID int, locale string, payload string) (string, error)
 	ShowTranslationFunc   func(articleID int, locale string) (string, error)
+	CreateUploadURLFunc   func(contentType string, fileSize int64) (*zendesk.UploadURLResponse, error)
+	UploadFileBinaryFunc  func(uploadURL string, headers map[string]string, body io.Reader) error
+	CreateGuideMediaFunc  func(assetUploadID, filename string) (*zendesk.GuideMedia, error)
+	ReplaceGuideMediaFunc func(id, assetUploadID, filename string) (*zendesk.GuideMedia, error)
+	DeleteGuideMediaFunc  func(id string) error
+	ListGuideMediasFunc   func() ([]*zendesk.GuideMedia, error)
 }
 
 // Article represents a Zendesk article for mock responses
@@ -112,6 +121,54 @@ func (m *MockZendeskClient) ShowTranslation(articleID int, locale string) (strin
 		return m.ShowTranslationFunc(articleID, locale)
 	}
 	return CreateDefaultTranslationResponse(1, articleID, locale), nil
+}
+
+// CreateUploadURL implements zendesk.Client
+func (m *MockZendeskClient) CreateUploadURL(contentType string, fileSize int64) (*zendesk.UploadURLResponse, error) {
+	if m.CreateUploadURLFunc != nil {
+		return m.CreateUploadURLFunc(contentType, fileSize)
+	}
+	return &zendesk.UploadURLResponse{}, nil
+}
+
+// UploadFileBinary implements zendesk.Client
+func (m *MockZendeskClient) UploadFileBinary(uploadURL string, headers map[string]string, body io.Reader) error {
+	if m.UploadFileBinaryFunc != nil {
+		return m.UploadFileBinaryFunc(uploadURL, headers, body)
+	}
+	return nil
+}
+
+// CreateGuideMedia implements zendesk.Client
+func (m *MockZendeskClient) CreateGuideMedia(assetUploadID, filename string) (*zendesk.GuideMedia, error) {
+	if m.CreateGuideMediaFunc != nil {
+		return m.CreateGuideMediaFunc(assetUploadID, filename)
+	}
+	return &zendesk.GuideMedia{}, nil
+}
+
+// ReplaceGuideMedia implements zendesk.Client
+func (m *MockZendeskClient) ReplaceGuideMedia(id, assetUploadID, filename string) (*zendesk.GuideMedia, error) {
+	if m.ReplaceGuideMediaFunc != nil {
+		return m.ReplaceGuideMediaFunc(id, assetUploadID, filename)
+	}
+	return &zendesk.GuideMedia{}, nil
+}
+
+// DeleteGuideMedia implements zendesk.Client
+func (m *MockZendeskClient) DeleteGuideMedia(id string) error {
+	if m.DeleteGuideMediaFunc != nil {
+		return m.DeleteGuideMediaFunc(id)
+	}
+	return nil
+}
+
+// ListGuideMedias implements zendesk.Client
+func (m *MockZendeskClient) ListGuideMedias() ([]*zendesk.GuideMedia, error) {
+	if m.ListGuideMediasFunc != nil {
+		return m.ListGuideMediasFunc()
+	}
+	return nil, nil
 }
 
 // MockConverter is a mock implementation of converter.Converter

--- a/internal/zendesk/client.go
+++ b/internal/zendesk/client.go
@@ -14,6 +14,17 @@ const (
 	BaseURL = "https://%s.zendesk.com"
 )
 
+// HTTPError represents an HTTP response with an unexpected status code.
+// Its Error() string is identical to the legacy formatted error so that
+// existing callers and tests that match the error string keep working.
+type HTTPError struct {
+	StatusCode int
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("unexpected status code: %d", e.StatusCode)
+}
+
 type Client interface {
 	CreateArticle(locale string, sectionID int, payload string) (string, error)
 	UpdateArticle(locale string, articleID int, payload string) (string, error)
@@ -22,6 +33,12 @@ type Client interface {
 	CreateTranslation(articleID int, payload string) (string, error)
 	UpdateTranslation(articleID int, locale string, payload string) (string, error)
 	ShowTranslation(articleID int, locale string) (string, error)
+	CreateUploadURL(contentType string, fileSize int64) (*UploadURLResponse, error)
+	UploadFileBinary(uploadURL string, headers map[string]string, body io.Reader) error
+	CreateGuideMedia(assetUploadID, filename string) (*GuideMedia, error)
+	ReplaceGuideMedia(id, assetUploadID, filename string) (*GuideMedia, error)
+	DeleteGuideMedia(id string) error
+	ListGuideMedias() ([]*GuideMedia, error)
 }
 
 type clientImpl struct {
@@ -138,7 +155,7 @@ func (c *clientImpl) doRequest(method string, endpoint string, payload io.Reader
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("unexpected status code: %d", res.StatusCode)
+		return "", &HTTPError{StatusCode: res.StatusCode}
 	}
 
 	resPayload, err := io.ReadAll(res.Body)
@@ -169,7 +186,7 @@ func (c *clientImpl) doDeleteRequest(endpoint string) error {
 	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+		return &HTTPError{StatusCode: res.StatusCode}
 	}
 	return nil
 }

--- a/internal/zendesk/media.go
+++ b/internal/zendesk/media.go
@@ -1,0 +1,193 @@
+package zendesk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// UploadURLResponse holds the parsed response from
+// POST /api/v2/guide/medias/upload_url. The Zendesk wire format wraps these
+// fields under an "upload_url" object and serializes Headers as a JSON-encoded
+// string; CreateUploadURL flattens that into this straightforward struct.
+type UploadURLResponse struct {
+	UploadURL     string
+	AssetUploadID string
+	Headers       map[string]string
+}
+
+// GuideMedia represents a Zendesk Guide Media object.
+type GuideMedia struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	URL     string `json:"url"`
+	Version int    `json:"version"`
+}
+
+type uploadURLReqBody struct {
+	ContentType string `json:"content_type"`
+	FileSize    int64  `json:"file_size"`
+}
+
+// uploadURLWireResp matches Zendesk's actual response shape:
+//
+//	{"upload_url":{"url":"...","asset_upload_id":"...","headers":"<json-encoded string>"}}
+type uploadURLWireResp struct {
+	UploadURL struct {
+		URL           string `json:"url"`
+		AssetUploadID string `json:"asset_upload_id"`
+		Headers       string `json:"headers"`
+	} `json:"upload_url"`
+}
+
+type guideMediaReqBody struct {
+	AssetUploadID string `json:"asset_upload_id"`
+	Filename      string `json:"filename"`
+}
+
+type wrappedGuideMediaResp struct {
+	GuideMedia GuideMedia `json:"media"`
+}
+
+type guideMediaListResp struct {
+	Records []GuideMedia `json:"records"`
+	Meta    struct {
+		HasMore     bool   `json:"has_more"`
+		AfterCursor string `json:"after_cursor"`
+	} `json:"meta"`
+}
+
+const guideMediaListPageSize = 100
+
+// refs: https://developer.zendesk.com/api-reference/help_center/help-center-api/guide_medias/#create-upload-url-for-a-guide-media-object
+func (c *clientImpl) CreateUploadURL(contentType string, fileSize int64) (*UploadURLResponse, error) {
+	b, err := json.Marshal(uploadURLReqBody{ContentType: contentType, FileSize: fileSize})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.doRequest(http.MethodPost, "/api/v2/guide/medias/upload_url", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var wire uploadURLWireResp
+	if err := json.Unmarshal([]byte(resp), &wire); err != nil {
+		return nil, err
+	}
+	// The headers field is a JSON-encoded string, so it needs a second decode.
+	var headers map[string]string
+	if wire.UploadURL.Headers != "" {
+		if err := json.Unmarshal([]byte(wire.UploadURL.Headers), &headers); err != nil {
+			return nil, fmt.Errorf("decode upload_url headers: %w", err)
+		}
+	}
+	return &UploadURLResponse{
+		UploadURL:     wire.UploadURL.URL,
+		AssetUploadID: wire.UploadURL.AssetUploadID,
+		Headers:       headers,
+	}, nil
+}
+
+// UploadFileBinary PUTs the body to the given signed upload URL with the
+// supplied headers. If body implements io.ReadSeeker, Content-Length is set
+// automatically.
+func (c *clientImpl) UploadFileBinary(uploadURL string, headers map[string]string, body io.Reader) error {
+	req, err := http.NewRequest(http.MethodPut, uploadURL, body)
+	if err != nil {
+		return err
+	}
+	if rs, ok := body.(io.ReadSeeker); ok {
+		pos, _ := rs.Seek(0, io.SeekCurrent)
+		end, _ := rs.Seek(0, io.SeekEnd)
+		_, _ = rs.Seek(pos, io.SeekStart)
+		req.ContentLength = end - pos
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	res, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return &HTTPError{StatusCode: res.StatusCode}
+	}
+	return nil
+}
+
+// refs: https://developer.zendesk.com/api-reference/help_center/help-center-api/guide_medias/#create-guide-media
+func (c *clientImpl) CreateGuideMedia(assetUploadID, filename string) (*GuideMedia, error) {
+	b, err := json.Marshal(guideMediaReqBody{
+		AssetUploadID: assetUploadID,
+		Filename:      filename,
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.doRequest(http.MethodPost, "/api/v2/guide/medias", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var wrapped wrappedGuideMediaResp
+	if err := json.Unmarshal([]byte(resp), &wrapped); err != nil {
+		return nil, err
+	}
+	return &wrapped.GuideMedia, nil
+}
+
+// refs: https://developer.zendesk.com/api-reference/help_center/help-center-api/guide_medias/#replace-guide-media-object
+func (c *clientImpl) ReplaceGuideMedia(id, assetUploadID, filename string) (*GuideMedia, error) {
+	b, err := json.Marshal(guideMediaReqBody{
+		AssetUploadID: assetUploadID,
+		Filename:      filename,
+	})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.doRequest(http.MethodPut, fmt.Sprintf("/api/v2/guide/medias/%s", id), bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	var wrapped wrappedGuideMediaResp
+	if err := json.Unmarshal([]byte(resp), &wrapped); err != nil {
+		return nil, err
+	}
+	return &wrapped.GuideMedia, nil
+}
+
+// refs: https://developer.zendesk.com/api-reference/help_center/help-center-api/guide_medias/#delete-guide-media-object
+func (c *clientImpl) DeleteGuideMedia(id string) error {
+	return c.doDeleteRequest(fmt.Sprintf("/api/v2/guide/medias/%s", id))
+}
+
+// refs: https://developer.zendesk.com/api-reference/help_center/help-center-api/guide_medias/#search-guide-media
+// Pages through all results using cursor-based pagination via meta.after_cursor.
+func (c *clientImpl) ListGuideMedias() ([]*GuideMedia, error) {
+	var all []*GuideMedia
+	cursor := ""
+	for {
+		endpoint := fmt.Sprintf("/api/v2/guide/medias?page[size]=%d", guideMediaListPageSize)
+		if cursor != "" {
+			endpoint += "&page[after]=" + url.QueryEscape(cursor)
+		}
+		resp, err := c.doRequest(http.MethodGet, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		var page guideMediaListResp
+		if err := json.Unmarshal([]byte(resp), &page); err != nil {
+			return nil, err
+		}
+		for i := range page.Records {
+			all = append(all, &page.Records[i])
+		}
+		if !page.Meta.HasMore || page.Meta.AfterCursor == "" {
+			break
+		}
+		cursor = page.Meta.AfterCursor
+	}
+	return all, nil
+}

--- a/internal/zendesk/media_test.go
+++ b/internal/zendesk/media_test.go
@@ -1,0 +1,621 @@
+package zendesk
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// readJSONBody decodes the request body into v. Fails the test if parsing errors.
+func readJSONBody(t *testing.T, r *http.Request, v interface{}) {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if err := json.Unmarshal(body, v); err != nil {
+		t.Fatalf("unmarshal body %q: %v", string(body), err)
+	}
+}
+
+func TestClient_CreateUploadURL(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotMethod, gotPath string
+		gotBody            uploadURLReqBody
+		rawBody            []byte
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		rawBody, _ = io.ReadAll(r.Body)
+		_ = json.Unmarshal(rawBody, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		// Real response shape: wrapped under "upload_url"; "headers" is a
+		// JSON-encoded string, not an object.
+		_, _ = w.Write([]byte(`{
+			"upload_url": {
+				"url": "https://upload-service.zendesk.com/abc?sig=xyz",
+				"asset_upload_id": "01HASSET",
+				"headers": "{\"Content-Type\":\"image/png\",\"X-Amz-Date\":\"20260101T000000Z\",\"X-Amz-Server-Side-Encryption\":\"AES256\"}"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	resp, err := c.CreateUploadURL("image/png", 12345)
+	if err != nil {
+		t.Fatalf("CreateUploadURL: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v2/guide/medias/upload_url" {
+		t.Errorf("path = %q", gotPath)
+	}
+	// Request body must be FLAT — Go's json.Unmarshal silently ignores extra
+	// wrapper keys, so verify against the raw bytes too.
+	if gotBody.ContentType != "image/png" || gotBody.FileSize != 12345 {
+		t.Errorf("body = %+v", gotBody)
+	}
+	if strings.Contains(string(rawBody), `"upload_url"`) {
+		t.Errorf("request body unexpectedly wrapped under upload_url: %s", rawBody)
+	}
+	if resp.UploadURL != "https://upload-service.zendesk.com/abc?sig=xyz" {
+		t.Errorf("UploadURL = %q", resp.UploadURL)
+	}
+	if resp.AssetUploadID != "01HASSET" {
+		t.Errorf("AssetUploadID = %q", resp.AssetUploadID)
+	}
+	for k, want := range map[string]string{
+		"Content-Type":                 "image/png",
+		"X-Amz-Date":                   "20260101T000000Z",
+		"X-Amz-Server-Side-Encryption": "AES256",
+	} {
+		if got := resp.Headers[k]; got != want {
+			t.Errorf("Headers[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestClient_CreateUploadURL_ServerError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	_, err := c.CreateUploadURL("image/png", 100)
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d", httpErr.StatusCode)
+	}
+}
+
+func TestClient_CreateUploadURL_MalformedOuterJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	if _, err := c.CreateUploadURL("image/png", 100); err == nil {
+		t.Fatal("expected error from malformed outer JSON, got nil")
+	}
+}
+
+// The inner headers field is itself a JSON-encoded string. If it cannot be
+// parsed as a header map, CreateUploadURL must surface an error rather than
+// silently dropping the signed headers (which would break the S3 upload).
+func TestClient_CreateUploadURL_MalformedHeadersString(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"upload_url": {
+				"url": "https://upload-service.zendesk.com/x",
+				"asset_upload_id": "01HASSET",
+				"headers": "not-a-json-object"
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	_, err := c.CreateUploadURL("image/png", 100)
+	if err == nil {
+		t.Fatal("expected error from malformed headers string, got nil")
+	}
+	if !strings.Contains(err.Error(), "headers") {
+		t.Errorf("err = %q, expected mention of 'headers'", err.Error())
+	}
+}
+
+// Empty headers string should produce a nil/empty Headers map rather than
+// erroring — defensive against minor doc/spec drift.
+func TestClient_CreateUploadURL_EmptyHeadersString(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{
+			"upload_url": {
+				"url": "https://upload-service.zendesk.com/x",
+				"asset_upload_id": "01HASSET",
+				"headers": ""
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	resp, err := c.CreateUploadURL("image/png", 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.UploadURL == "" {
+		t.Errorf("UploadURL should still be parsed even with empty headers")
+	}
+	if len(resp.Headers) != 0 {
+		t.Errorf("Headers should be empty, got %v", resp.Headers)
+	}
+}
+
+func TestClient_UploadFileBinary(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotMethod        string
+		gotHeaders       http.Header
+		gotBody          []byte
+		gotContentLength int64
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotHeaders = r.Header.Clone()
+		gotContentLength = r.ContentLength
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl("")
+	payload := []byte("PNG-binary-data-here")
+	headers := map[string]string{
+		"Content-Type":                 "image/png",
+		"X-Amz-Date":                   "20260101T000000Z",
+		"X-Amz-Server-Side-Encryption": "AES256",
+	}
+	if err := c.UploadFileBinary(server.URL, headers, bytes.NewReader(payload)); err != nil {
+		t.Fatalf("UploadFileBinary: %v", err)
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if !bytes.Equal(gotBody, payload) {
+		t.Errorf("body mismatch: got %q", gotBody)
+	}
+	if gotContentLength != int64(len(payload)) {
+		t.Errorf("Content-Length = %d, want %d", gotContentLength, len(payload))
+	}
+	for k, want := range headers {
+		if got := gotHeaders.Get(k); got != want {
+			t.Errorf("header %q = %q, want %q", k, got, want)
+		}
+	}
+}
+
+func TestClient_UploadFileBinary_S3Error(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl("")
+	err := c.UploadFileBinary(server.URL, nil, bytes.NewReader([]byte("x")))
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("expected *HTTPError, got %T: %v", err, err)
+	}
+	if httpErr.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("StatusCode = %d", httpErr.StatusCode)
+	}
+}
+
+// nonSeekerReader wraps a Reader to deliberately hide ReadSeeker so we can
+// verify that Content-Length is omitted when the body is not seekable.
+type nonSeekerReader struct{ r io.Reader }
+
+func (n *nonSeekerReader) Read(p []byte) (int, error) { return n.r.Read(p) }
+
+func TestClient_UploadFileBinary_NonSeekableNoContentLength(t *testing.T) {
+	t.Parallel()
+
+	var gotContentLength int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentLength = r.ContentLength
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl("")
+	payload := []byte("not seekable")
+	body := &nonSeekerReader{r: bytes.NewReader(payload)}
+	if err := c.UploadFileBinary(server.URL, nil, body); err != nil {
+		t.Fatalf("UploadFileBinary: %v", err)
+	}
+
+	if gotContentLength == int64(len(payload)) {
+		t.Errorf("Content-Length unexpectedly set to %d for non-seekable body", gotContentLength)
+	}
+}
+
+func TestClient_CreateGuideMedia(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotMethod, gotPath string
+		gotBody            guideMediaReqBody
+		// Capture raw body to assert it's NOT wrapped under "media" or "guide_media".
+		rawBody []byte
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		rawBody, _ = io.ReadAll(r.Body)
+		_ = json.Unmarshal(rawBody, &gotBody)
+		// Real response wrapper key is "media" (not "guide_media").
+		_, _ = w.Write([]byte(`{
+			"media": {
+				"access_key": "01ASSET",
+				"content_type": "image/png",
+				"created_at": "2026-05-10T00:00:00.000Z",
+				"id": "01HMEDIA",
+				"name": "uploads/foo.png",
+				"size": 10394,
+				"updated_at": "2026-05-10T00:00:00.000Z",
+				"url": "/guide-media/01ASSET",
+				"version": 1
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	media, err := c.CreateGuideMedia("01ASSET", "uploads/foo.png")
+	if err != nil {
+		t.Fatalf("CreateGuideMedia: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/api/v2/guide/medias" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotBody.AssetUploadID != "01ASSET" || gotBody.Filename != "uploads/foo.png" {
+		t.Errorf("body = %+v", gotBody)
+	}
+	// Request must NOT be wrapped under any key.
+	for _, banned := range []string{`"media"`, `"guide_media"`} {
+		if strings.Contains(string(rawBody), banned) {
+			t.Errorf("request body unexpectedly wrapped (contains %s): %s", banned, rawBody)
+		}
+	}
+	// Response must be unwrapped from "media".
+	if media.ID != "01HMEDIA" || media.Name != "uploads/foo.png" || media.Version != 1 {
+		t.Errorf("media = %+v", media)
+	}
+	if media.URL != "/guide-media/01ASSET" {
+		t.Errorf("media.URL = %q", media.URL)
+	}
+}
+
+func TestClient_CreateGuideMedia_Conflict(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	_, err := c.CreateGuideMedia("asset", "foo.png")
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusConflict {
+		t.Errorf("expected 409 *HTTPError, got %v", err)
+	}
+}
+
+func TestClient_ReplaceGuideMedia(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotMethod, gotPath string
+		gotBody            guideMediaReqBody
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		readJSONBody(t, r, &gotBody)
+		_, _ = w.Write([]byte(`{
+			"media": {
+				"id": "01HMEDIA",
+				"name": "uploads/foo.png",
+				"url": "/guide-media/01ASSET2",
+				"version": 2
+			}
+		}`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	media, err := c.ReplaceGuideMedia("01HMEDIA", "01ASSET2", "uploads/foo.png")
+	if err != nil {
+		t.Fatalf("ReplaceGuideMedia: %v", err)
+	}
+
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
+	if gotPath != "/api/v2/guide/medias/01HMEDIA" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotBody.AssetUploadID != "01ASSET2" {
+		t.Errorf("AssetUploadID = %q", gotBody.AssetUploadID)
+	}
+	if media.Version != 2 {
+		t.Errorf("Version = %d, want 2", media.Version)
+	}
+}
+
+func TestClient_DeleteGuideMedia(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		serverStatus int
+		wantErrCode  int // 0 means expect no error
+	}{
+		{"success 204", http.StatusNoContent, 0},
+		{"not found 404", http.StatusNotFound, http.StatusNotFound},
+		{"server error 500", http.StatusInternalServerError, http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotMethod, gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotMethod = r.Method
+				gotPath = r.URL.Path
+				w.WriteHeader(tt.serverStatus)
+			}))
+			defer server.Close()
+
+			c := newTestClientImpl(server.URL)
+			err := c.DeleteGuideMedia("01HMEDIA")
+
+			if tt.wantErrCode == 0 {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+			} else {
+				var httpErr *HTTPError
+				if !errors.As(err, &httpErr) || httpErr.StatusCode != tt.wantErrCode {
+					t.Errorf("expected %d *HTTPError, got %v", tt.wantErrCode, err)
+				}
+			}
+			if gotMethod != http.MethodDelete {
+				t.Errorf("method = %q, want DELETE", gotMethod)
+			}
+			if gotPath != "/api/v2/guide/medias/01HMEDIA" {
+				t.Errorf("path = %q", gotPath)
+			}
+		})
+	}
+}
+
+func TestClient_ListGuideMedias_SinglePage(t *testing.T) {
+	t.Parallel()
+
+	var requestCount int
+	var firstQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestCount == 0 {
+			firstQuery = r.URL.RawQuery
+		}
+		requestCount++
+		// Real response wrapper is "records", not "guide_medias".
+		_, _ = w.Write([]byte(`{
+			"meta": {"has_more": false, "after_cursor": "", "before_cursor": ""},
+			"records": [
+				{"id":"01A","name":"a.png","url":"/guide-media/a","version":1},
+				{"id":"01B","name":"b.png","url":"/guide-media/b","version":2}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	medias, err := c.ListGuideMedias()
+	if err != nil {
+		t.Fatalf("ListGuideMedias: %v", err)
+	}
+
+	if requestCount != 1 {
+		t.Errorf("requestCount = %d, want 1", requestCount)
+	}
+	// page[size]=100 must be on the first request — sometimes percent-encoded.
+	if !strings.Contains(firstQuery, "page%5Bsize%5D=100") && !strings.Contains(firstQuery, "page[size]=100") {
+		t.Errorf("first query = %q, expected to include page[size]=100", firstQuery)
+	}
+	if len(medias) != 2 {
+		t.Fatalf("len(medias) = %d, want 2", len(medias))
+	}
+	if medias[0].ID != "01A" || medias[1].ID != "01B" {
+		t.Errorf("ids = %q,%q", medias[0].ID, medias[1].ID)
+	}
+}
+
+func TestClient_ListGuideMedias_MultiPage(t *testing.T) {
+	t.Parallel()
+
+	var receivedCursors []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the cursor sent on each request so we can assert pagination.
+		receivedCursors = append(receivedCursors, r.URL.Query().Get("page[after]"))
+		switch r.URL.Query().Get("page[after]") {
+		case "":
+			_, _ = fmt.Fprint(w, `{
+				"meta": {"has_more": true, "after_cursor": "MQ"},
+				"records": [{"id":"01A","name":"a.png","url":"/guide-media/a","version":1}]
+			}`)
+		case "MQ":
+			_, _ = fmt.Fprint(w, `{
+				"meta": {"has_more": true, "after_cursor": "Mg"},
+				"records": [{"id":"01B","name":"b.png","url":"/guide-media/b","version":1}]
+			}`)
+		case "Mg":
+			_, _ = fmt.Fprint(w, `{
+				"meta": {"has_more": false, "after_cursor": ""},
+				"records": [{"id":"01C","name":"c.png","url":"/guide-media/c","version":1}]
+			}`)
+		default:
+			t.Errorf("unexpected page[after] = %q", r.URL.Query().Get("page[after]"))
+		}
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	medias, err := c.ListGuideMedias()
+	if err != nil {
+		t.Fatalf("ListGuideMedias: %v", err)
+	}
+
+	if got, want := len(receivedCursors), 3; got != want {
+		t.Fatalf("requests = %d, want %d (cursors: %v)", got, want, receivedCursors)
+	}
+	if receivedCursors[0] != "" || receivedCursors[1] != "MQ" || receivedCursors[2] != "Mg" {
+		t.Errorf("cursors received = %v, want [empty MQ Mg]", receivedCursors)
+	}
+	if len(medias) != 3 {
+		t.Fatalf("len(medias) = %d, want 3", len(medias))
+	}
+	wantIDs := []string{"01A", "01B", "01C"}
+	for i, want := range wantIDs {
+		if medias[i].ID != want {
+			t.Errorf("medias[%d].ID = %q, want %q", i, medias[i].ID, want)
+		}
+	}
+}
+
+// Cursors may include characters that need URL-encoding (e.g. '+', '/'). Verify
+// that a cursor containing a '+' is correctly forwarded by the next request.
+func TestClient_ListGuideMedias_URLEncodesCursor(t *testing.T) {
+	t.Parallel()
+
+	const trickyCursor = "abc+def/ghi="
+	var receivedCursors []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCursors = append(receivedCursors, r.URL.Query().Get("page[after]"))
+		if len(receivedCursors) == 1 {
+			_, _ = fmt.Fprintf(w, `{"meta":{"has_more":true,"after_cursor":%q},"records":[]}`, trickyCursor)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"meta":{"has_more":false,"after_cursor":""},"records":[]}`)
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	if _, err := c.ListGuideMedias(); err != nil {
+		t.Fatal(err)
+	}
+	// The Go server side decodes query params, so r.URL.Query().Get reveals the
+	// post-decode cursor. If we URL-encode correctly, this round-trips.
+	if receivedCursors[1] != trickyCursor {
+		t.Errorf("decoded cursor = %q, want %q (url encoding lost roundtrip)", receivedCursors[1], trickyCursor)
+	}
+	// Sanity check our own URL encoding logic too.
+	if got := url.QueryEscape(trickyCursor); !strings.Contains(got, "%2B") {
+		t.Errorf("url.QueryEscape did not encode '+': %q", got)
+	}
+}
+
+// has_more=true but after_cursor="" must terminate pagination instead of
+// looping forever (defensive against malformed server responses).
+func TestClient_ListGuideMedias_StopsOnEmptyCursor(t *testing.T) {
+	t.Parallel()
+
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount > 1 {
+			t.Errorf("server called more than once: %d", requestCount)
+		}
+		_, _ = w.Write([]byte(`{
+			"meta": {"has_more": true, "after_cursor": ""},
+			"records": [{"id":"01A","name":"a.png","url":"/guide-media/a","version":1}]
+		}`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	medias, err := c.ListGuideMedias()
+	if err != nil {
+		t.Fatalf("ListGuideMedias: %v", err)
+	}
+	if len(medias) != 1 {
+		t.Errorf("len(medias) = %d, want 1", len(medias))
+	}
+}
+
+func TestClient_ListGuideMedias_PropagatesError(t *testing.T) {
+	t.Parallel()
+
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			_, _ = w.Write([]byte(`{
+				"meta": {"has_more": true, "after_cursor": "MQ"},
+				"records": [{"id":"01A","name":"a.png","url":"/guide-media/a","version":1}]
+			}`))
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	_, err := c.ListGuideMedias()
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500 *HTTPError after page 2 failure, got %v", err)
+	}
+}

--- a/internal/zendesk/media_test.go
+++ b/internal/zendesk/media_test.go
@@ -619,3 +619,76 @@ func TestClient_ListGuideMedias_PropagatesError(t *testing.T) {
 		t.Errorf("expected 500 *HTTPError after page 2 failure, got %v", err)
 	}
 }
+
+func TestClient_ListGuideMedias_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	if _, err := c.ListGuideMedias(); err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestClient_CreateGuideMedia_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	if _, err := c.CreateGuideMedia("asset", "foo.png"); err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestClient_ReplaceGuideMedia_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{not json`))
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	if _, err := c.ReplaceGuideMedia("01HM", "asset", "foo.png"); err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestClient_ReplaceGuideMedia_HTTPError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	c := newTestClientImpl(server.URL)
+	_, err := c.ReplaceGuideMedia("01HM", "asset", "foo.png")
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) || httpErr.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 *HTTPError, got %v", err)
+	}
+}
+
+func TestClient_UploadFileBinary_TransportError(t *testing.T) {
+	t.Parallel()
+
+	// Start and immediately close the server so Do() fails on connect.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close()
+
+	c := newTestClientImpl("")
+	err := c.UploadFileBinary(server.URL, nil, bytes.NewReader([]byte("x")))
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `zgsync media` subcommand with 4 actions (`create` / `update` / `list` / `delete`) for managing images via the Zendesk Guide Media API
- Implement the 3-step Zendesk upload flow: signed URL request → S3 PUT → Guide Media object creation
- Retry on 5xx and network timeout (default 3 retries, no backoff)
- Restrict uploads to `image/png`, `image/jpeg`, `image/gif`, `image/webp`

## Subcommands

### `zgsync media create <file>`

Uploads an image and creates a new Guide Media object.

| Flag | Description |
|---|---|
| `--dry-run` | Print what would be uploaded without contacting the API |

The Guide Media `name` field is set to the image path **relative to CWD** (e.g. `images/screenshot.png`). When the file lives outside the CWD subtree, the basename is used as a fallback. This way, `media list` can show which local file each remote URL corresponds to without keeping any local mapping file.

```
$ zgsync media create images/screenshot.png
Uploading images/screenshot.png...
  Guide Media ID:  01ARZ3NDEKTSV4RRFFQ69G5FAV
  URL:             https://your-subdomain.zendesk.com/hc/article_attachments/...
```

### `zgsync media update --media-id <id> <file>`

Replaces an existing Guide Media's content. **The URL stays the same**, so embedded references in articles never need to be updated.

| Flag | Required | Description |
|---|---|---|
| `--media-id` | Yes | ULID of the target Guide Media |
| `--dry-run` | No | Preview only |

```
$ zgsync media update --media-id 01ARZ3... screenshot-v2.png
Uploading screenshot-v2.png...
  Guide Media ID:  01ARZ3NDEKTSV4RRFFQ69G5FAV
  URL:             https://your-subdomain.zendesk.com/hc/article_attachments/...
  Version:         2
```

### `zgsync media list`

Lists all Guide Media as a `local-path → {media-id, url, version}` mapping. Paginates internally via `meta.after_cursor` until `has_more` is false.

| Flag | Default | Description |
|---|---|---|
| `--output` | `table` | One of `table`, `yaml`, `markdown` |

YAML output preserves the path → URL mapping for reuse in scripts or as a reference file:

```yaml
images/screenshot.png:
  media_id: 01ARZ3NDEKTSV4RRFFQ69G5FAV
  url: https://your-subdomain.zendesk.com/hc/article_attachments/...
  version: 1
```

### `zgsync media delete --media-id <id>`

Deletes the specified Guide Media. Prints a warning beforehand that articles embedding the image will break.

| Flag | Required | Description |
|---|---|---|
| `--media-id` | Yes | ULID of the target Guide Media |
| `--dry-run` | No | Preview only |

## Workflow integration

After uploading, paste the returned URL into your Markdown:

```markdown
![alt](https://your-subdomain.zendesk.com/hc/article_attachments/...)
```

When the article is pushed via `zgsync push`, Zendesk auto-creates an Article Attachment for each locale, so multilingual articles work without any extra step.

## Retry & error handling

- Retries only on 5xx HTTP responses and network timeouts; 4xx fails immediately
- Each retry restarts from Step 1 (a fresh signed URL); the file is rewound (`Seek(0)`) between attempts
- On exhaustion: `Error: failed to {create,replace} Guide Media (gave up after 3 retries). Please retry the command`
- Known limitation: a Step 3 network timeout may create a Guide Media on Zendesk's side without delivering the response, producing duplicates. These can be detected with `media list` and pruned with `media delete`.

## API contract notes

Implementation matches the response examples in the [Guide Medias API docs](https://developer.zendesk.com/api-reference/help_center/help-center-api/guide_medias/):

- `POST /api/v2/guide/medias/upload_url` — request flat; response wrapped under `upload_url`, with `headers` as a **JSON-encoded string** that the client decodes into a `map[string]string` before forwarding to S3
- `POST` / `PUT /api/v2/guide/medias` — request flat; response wrapped under `media`
- `GET /api/v2/guide/medias` — paginated via `page[size]=100` + `page[after]=<meta.after_cursor>`; items in `records[]`
- `DELETE /api/v2/guide/medias/{id}` — `204 No Content`

## Test plan

- [x] `make test` — all packages pass
- [x] `make lint` — 0 issues
- [x] `make build` — produces working `dist/zgsync` with `media` subcommand visible in `--help`
- [ ] Smoke test against a real Zendesk account: `media create` → embed URL in article → `push` → confirm article renders the image
- [ ] Smoke test `media list` against an account with > 100 Guide Media to verify pagination
- [ ] Smoke test `media update` — confirm version increments and URL is preserved