### PR TITLE
chore(ci): harden GitHub Actions against supply chain risks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,29 +5,34 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   DEBIAN_FRONTEND: noninteractive
   TZ: 'Asia/Tokyo'
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
   test:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macOS-latest']
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version-file: 'go.mod'
-    - uses: actions/cache@v5
+    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -35,7 +40,7 @@ jobs:
           ${{ runner.os }}-go-
     - run: go test -v -coverprofile=coverage.out ./...
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
       with:
         file: ./coverage.out
         flags: unittests

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -4,9 +4,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   tagpr:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       tagpr-tag: ${{ steps.run-tagpr.outputs.tag }}
     permissions:
@@ -15,12 +19,12 @@ jobs:
       issues: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - id: run-tagpr
         name: Run tagpr
-        uses: Songmu/tagpr@v1
+        uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -28,27 +32,28 @@ jobs:
     needs: tagpr
     if: needs.tagpr.outputs.tagpr-tag != ''
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
       - name: Generate Token
         id: generate_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.TOKEN_APP_ID }}
           private-key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Pin all 8 GitHub Actions to full commit SHAs to mitigate mutable-tag attacks
- Apply least-privilege defaults (`permissions: contents: read`) and `timeout-minutes` to every job
- Replace GoReleaser CLI `version: latest` with `~> v2` to block accidental major upgrades
- Enable Renovate `helpers:pinGitHubActionDigests` to keep SHA pins fresh and group updates

## Changes

### `.github/workflows/ci.yaml`
- Add top-level `permissions: contents: read`
- Add `timeout-minutes: 10` to `lint` and `test` jobs
- Pin `actions/checkout`, `actions/setup-go`, `actions/cache`, `golangci/golangci-lint-action`, `codecov/codecov-action` to commit SHAs with `# vX.Y.Z` comments

### `.github/workflows/tagpr.yml`
- Add top-level `permissions: contents: read`; per-job permissions remain for required write access
- Add `timeout-minutes: 10` to `tagpr` and `timeout-minutes: 30` to `goreleaser`
- Pin `actions/checkout`, `actions/setup-go`, `actions/create-github-app-token`, `Songmu/tagpr`, `goreleaser/goreleaser-action` to commit SHAs
- Replace `goreleaser-action` `version: latest` with `version: '~> v2'`

### `renovate.json`
- Extend with `helpers:pinGitHubActionDigests` to maintain digest pins
- Group all `github-actions` manager updates into a single PR

## References
- OpenSSF Scorecard: Pinned-Dependencies / Token-Permissions
- GitHub: Security hardening for GitHub Actions
- Recent supply chain incidents: `tj-actions/changed-files` (Mar 2025)