### PR TITLE
feat: add OAuth authentication support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,12 @@ Expects `~/.config/zgsync/config.yaml` with the fields listed below.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `subdomain` | string | Yes | Zendesk subdomain |
-| `email` | string | Yes | Zendesk email (`user@example.com/token` format) |
-| `token` | string | Yes | Zendesk API token |
+| `auth_type` | string | No | `token` (default), `oauth`, or `client_credentials` |
+| `email` | string | token auth | Zendesk email (`user@example.com/token` format) |
+| `token` | string | token auth | Zendesk API token |
+| `oauth_client_id` | string | oauth / client_credentials | OAuth client ID (env: `ZGSYNC_OAUTH_CLIENT_ID`) |
+| `oauth_client_secret` | — | client_credentials | Env-only (`ZGSYNC_OAUTH_CLIENT_SECRET`); not read from the config file |
+| `oauth_scope` | string | No | OAuth scope (default: `hc:read hc:write`) |
 | `default_locale` | string | Yes | Default locale for articles |
 | `default_permission_group_id` | int | Yes | Default permission group ID |
 | `contents_dir` | string | No | Path to contents directory (default: `.`) |
@@ -144,7 +148,9 @@ Expects `~/.config/zgsync/config.yaml` with the fields listed below.
 1. **push**: Update Translations or Articles to Zendesk
 2. **pull**: Retrieve Translations or Articles from Zendesk
 3. **empty**: Create empty draft articles
-4. **version**: Show version information
+4. **archive**: Archive articles on the remote
+5. **auth login**: Log in via OAuth (authorization code grant with PKCE) and save tokens to `~/.config/zgsync/credentials.json`
+6. **version**: Show version information
 
 ## CI/CD & Release Flow
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,11 @@ enable_link_target_blank: false
 | Key                         | Required | Description                                              |
 | --------------------------- | -------- | -------------------------------------------------------- |
 | subdomain                   | true     | Specify a brand-specific subdomain                       |
-| email                       | true     | Specify the email address with "/token" added to the end |
-| token                       | true     | Specify your API token                                   |
+| auth_type                   | false    | Authentication type: `token` (default), `oauth`, or `client_credentials` |
+| email                       | (1)      | Specify the email address with "/token" added to the end |
+| token                       | (1)      | Specify your API token                                   |
+| oauth_client_id             | (2)      | OAuth client ID (identifier)                             |
+| oauth_scope                 | false    | OAuth scope (default: `hc:read hc:write`)                |
 | default_comments_disabled   | true     | Specify the default comments disabled                    |
 | default_locale              | true     | Specify the default locale for translations              |
 | default_permission_group_id | true     | Specify the default permission group ID                  |
@@ -54,9 +57,70 @@ enable_link_target_blank: false
 | contents_dir                | false    | Specify the local directory path to manage articles      |
 | enable_link_target_blank    | false    | Specify if links open in a new tab (affected only push)  |
 
+- (1) Required when `auth_type` is `token`.
+- (2) Required when `auth_type` is `oauth` or `client_credentials`.
+
+The OAuth client secret (required for `auth_type: client_credentials`) is only accepted via the `ZGSYNC_OAUTH_CLIENT_SECRET` environment variable so that it never has to be written to a file.
+
+## Authentication
+
+> [!WARNING]
+> Zendesk is [deprecating API tokens](https://support.zendesk.com/hc/en-us/articles/10851263566234): new token creation will be blocked on October 27, 2026, and all tokens will stop working on April 30, 2027. Migrate to OAuth before then. The `token` auth type remains supported until the deprecation for backward compatibility.
+
+### OAuth for local use (`auth_type: oauth`)
+
+Create an OAuth client in the Zendesk Admin Center (Apps and integrations > APIs > OAuth clients) with:
+
+- **Client kind**: Public
+- **Redirect URLs**: `http://localhost:8976/callback`
+
+Then configure zgsync and log in:
+
+```yaml:~/.config/zgsync/config.yaml
+subdomain: <your zendesk subdomain>
+auth_type: oauth
+oauth_client_id: <your oauth client identifier>
+# ... other settings
+```
+
+```
+zgsync auth login
+```
+
+This opens your browser to authorize zgsync (authorization code grant with PKCE; no client secret is needed).
+Tokens are saved to `~/.config/zgsync/credentials.json` and refreshed automatically.
+When the refresh token expires, run `zgsync auth login` again.
+
+### OAuth for CI (`auth_type: client_credentials`)
+
+Create a separate OAuth client with **Client kind: Confidential** and save its secret in your CI secrets.
+The client credentials grant obtains a short-lived access token at runtime, so no token needs to be stored.
+
+```yaml:config.yaml
+subdomain: <your zendesk subdomain>
+auth_type: client_credentials
+oauth_client_id: <your oauth client identifier>
+# ... other settings
+```
+
+The client secret is passed via the `ZGSYNC_OAUTH_CLIENT_SECRET` environment variable (it is not read from the config file). The client ID can also be overridden with `ZGSYNC_OAUTH_CLIENT_ID`.
+
+Example GitHub Actions workflow:
+
+```yaml
+- name: Push articles to Zendesk
+  env:
+    ZGSYNC_OAUTH_CLIENT_ID: ${{ secrets.ZENDESK_OAUTH_CLIENT_ID }}
+    ZGSYNC_OAUTH_CLIENT_SECRET: ${{ secrets.ZENDESK_OAUTH_CLIENT_SECRET }}
+  run: zgsync push --config ./zgsync.yaml docs/**/*.md
+```
+
+> [!NOTE]
+> With the client credentials grant, API requests are performed as the owner of the OAuth client. Articles created or updated from CI are attributed to that user.
+
 ## Usage
 
-zgsync consists of the subcommands pull, push, empty, and archive.
+zgsync consists of the subcommands pull, push, empty, archive, and auth.
 By default, it handles Translations among the data models of the Zendesk Help Center, but it can also handle Articles by specifying a specific option.
 
 zgsync saves Translations in files named `{Article ID}-{Locale}.md`. When using the pull or empty commands, specifying the `--save-article` option saves Articles in files named `{Article ID}.md`.  
@@ -134,6 +198,20 @@ Archives an article on the remote.
 
 Arguments:
   <target>    Specify the article ID or file path of the article to archive.
+```
+
+### auth login
+
+The auth login subcommand logs in to Zendesk via OAuth and saves the tokens to `~/.config/zgsync/credentials.json`. See [Authentication](#authentication) for the setup.
+
+```
+Usage: zgsync auth login [flags]
+
+Log in to Zendesk via OAuth (authorization code grant with PKCE) and save the tokens locally.
+
+Flags:
+      --port=8976                                Port of the local callback server. The OAuth client must register
+                                                 http://localhost:<port>/callback as a redirect URL.
 ```
 
 ## Markdown file format

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ enable_link_target_blank: false
 | auth_type                   | false    | Authentication type: `token` (default), `oauth`, or `client_credentials` |
 | email                       | (1)      | Specify the email address with "/token" added to the end |
 | token                       | (1)      | Specify your API token                                   |
-| oauth_client_id             | (2)      | OAuth client ID (identifier)                             |
+| oauth_client_id             | (2)      | OAuth client ID (identifier) (env: `ZGSYNC_OAUTH_CLIENT_ID`) |
 | oauth_scope                 | false    | OAuth scope (default: `hc:read hc:write`)                |
 | default_comments_disabled   | true     | Specify the default comments disabled                    |
 | default_locale              | true     | Specify the default locale for translations              |

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,20 +13,24 @@ type cli struct {
 	Pull    CommandPull    `cmd:"pull" help:"Pull translations or articles from the remote."`
 	Empty   CommandEmpty   `cmd:"empty" help:"Creates an empty draft article remotely and saves it locally."`
 	Archive CommandArchive `cmd:"archive" help:"Archive an article on the remote."`
+	Auth    CommandAuth    `cmd:"auth" help:"Manage OAuth authentication."`
 	Version CommandVersion `cmd:"version" help:"Show version."`
 }
 
 func (c *cli) AfterApply(kCtx *kong.Context) error {
-	if kCtx.Command() == "version" {
+	switch kCtx.Command() {
+	case "version":
 		return nil
+	case "auth login":
+		if err := c.ConfigExists(); err != nil {
+			return err
+		}
+		return c.LoadConfigForAuthLogin()
 	}
 	if err := c.ConfigExists(); err != nil {
 		return err
 	}
-	if err := c.LoadConfig(); err != nil {
-		return err
-	}
-	return nil
+	return c.LoadConfig()
 }
 
 func Bind() {

--- a/internal/cli/client_factory.go
+++ b/internal/cli/client_factory.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/tukaelu/zgsync/internal/zendesk"
+)
+
+// NewZendeskClient builds a Zendesk API client with credentials matching auth_type.
+func (g *Global) NewZendeskClient() (zendesk.Client, error) {
+	creds, err := g.newCredentials()
+	if err != nil {
+		return nil, err
+	}
+	return zendesk.NewClientWithCredentials(g.Config.Subdomain, creds), nil
+}
+
+func (g *Global) newCredentials() (zendesk.Credentials, error) {
+	switch g.Config.AuthType {
+	case "", AuthTypeToken:
+		return &zendesk.TokenCredentials{Email: g.Config.Email, Token: g.Config.Token}, nil
+	case AuthTypeOAuth:
+		store, err := NewCredentialStore()
+		if err != nil {
+			return nil, err
+		}
+		return newOAuthCredentials(g.Config, store)
+	case AuthTypeClientCredentials:
+		return &zendesk.ClientCredentialsProvider{
+			ClientID:     g.Config.OAuthClientID,
+			ClientSecret: g.Config.OAuthClientSecret,
+			Scope:        g.Config.OAuthScope,
+			OAuth:        zendesk.NewOAuthClient(g.Config.Subdomain),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported auth_type: %s", g.Config.AuthType)
+	}
+}
+
+func newOAuthCredentials(cfg Config, store *CredentialStore) (*zendesk.OAuthCredentials, error) {
+	cred, err := store.Load(cfg.Subdomain)
+	if err != nil {
+		return nil, err
+	}
+	// The refresh token is bound to the client that issued it, so a config
+	// client ID that differs from the stored one can never refresh successfully.
+	if cfg.OAuthClientID != "" && cred.ClientID != "" && cfg.OAuthClientID != cred.ClientID {
+		return nil, fmt.Errorf(
+			"oauth_client_id %q does not match the client %q the saved tokens were issued to; run `zgsync auth login` again",
+			cfg.OAuthClientID, cred.ClientID,
+		)
+	}
+	clientID := cred.ClientID
+	if clientID == "" {
+		clientID = cfg.OAuthClientID
+	}
+	return &zendesk.OAuthCredentials{
+		AccessToken:  cred.AccessToken,
+		RefreshToken: cred.RefreshToken,
+		Expiry:       cred.Expiry,
+		ClientID:     clientID,
+		OAuth:        zendesk.NewOAuthClient(cfg.Subdomain),
+		OnRefresh: func(accessToken, refreshToken string, expiry time.Time) error {
+			// Re-load so a login performed while this process was running
+			// is not clobbered with the startup-time snapshot.
+			latest, err := store.Load(cfg.Subdomain)
+			if err != nil {
+				latest = cred
+			}
+			latest.AccessToken = accessToken
+			latest.RefreshToken = refreshToken
+			latest.Expiry = expiry
+			if err := store.Save(cfg.Subdomain, latest); err != nil {
+				// Zendesk already rotated the refresh token; failing here would
+				// discard a valid access token, so warn and keep going.
+				fmt.Fprintf(os.Stderr,
+					"warning: failed to save refreshed tokens to %s: %v\nif the next run fails to authenticate, run `zgsync auth login` again\n",
+					store.Path(), err,
+				)
+			}
+			return nil
+		},
+	}, nil
+}

--- a/internal/cli/client_factory_test.go
+++ b/internal/cli/client_factory_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tukaelu/zgsync/internal/zendesk"
+)
+
+func TestGlobal_NewZendeskClient_AuthTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		config    Config
+		expectErr string
+	}{
+		{
+			name:   "token auth",
+			config: Config{Subdomain: "test", AuthType: AuthTypeToken, Email: "user@example.com/token", Token: "token123"},
+		},
+		{
+			name:   "empty auth_type falls back to token",
+			config: Config{Subdomain: "test", Email: "user@example.com/token", Token: "token123"},
+		},
+		{
+			name:   "client_credentials auth",
+			config: Config{Subdomain: "test", AuthType: AuthTypeClientCredentials, OAuthClientID: "ci", OAuthClientSecret: "secret", OAuthScope: DefaultOAuthScope},
+		},
+		{
+			name:      "unsupported auth_type",
+			config:    Config{Subdomain: "test", AuthType: "bogus"},
+			expectErr: "unsupported auth_type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			g := &Global{Config: tt.config}
+			client, err := g.NewZendeskClient()
+
+			if tt.expectErr != "" {
+				if err == nil {
+					t.Fatalf("NewZendeskClient() = nil error, want error containing %q", tt.expectErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectErr) {
+					t.Errorf("NewZendeskClient() error = %v, want error containing %q", err, tt.expectErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewZendeskClient() error = %v", err)
+			}
+			if got := zendesk.ClientBaseURL(client); got != "https://test.zendesk.com" {
+				t.Errorf("ClientBaseURL() = %s, want https://test.zendesk.com", got)
+			}
+		})
+	}
+}
+
+func TestNewOAuthCredentials_FromStore(t *testing.T) {
+	t.Parallel()
+
+	store := NewCredentialStoreWithPath(t.TempDir() + "/credentials.json")
+	if err := store.Save("test", &StoredCredential{
+		ClientID:     "storedclient",
+		AccessToken:  "access123",
+		RefreshToken: "refresh456",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := newOAuthCredentials(Config{Subdomain: "test"}, store)
+	if err != nil {
+		t.Fatalf("newOAuthCredentials() error = %v", err)
+	}
+
+	if creds.ClientID != "storedclient" {
+		t.Errorf("ClientID = %s, want storedclient (from store)", creds.ClientID)
+	}
+	authz, err := creds.AuthorizationHeader()
+	if err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
+	if authz != "Bearer access123" {
+		t.Errorf("AuthorizationHeader() = %s, want Bearer access123", authz)
+	}
+}
+
+func TestNewOAuthCredentials_ClientIDMismatchIsRejected(t *testing.T) {
+	t.Parallel()
+
+	store := NewCredentialStoreWithPath(t.TempDir() + "/credentials.json")
+	if err := store.Save("test", &StoredCredential{ClientID: "storedclient", AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := newOAuthCredentials(Config{Subdomain: "test", OAuthClientID: "configclient"}, store)
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "does not match") || !strings.Contains(err.Error(), "auth login") {
+		t.Errorf("Expected client ID mismatch error suggesting `auth login`, got: %v", err)
+	}
+}
+
+func TestNewOAuthCredentials_MatchingClientIDIsAccepted(t *testing.T) {
+	t.Parallel()
+
+	store := NewCredentialStoreWithPath(t.TempDir() + "/credentials.json")
+	if err := store.Save("test", &StoredCredential{ClientID: "myclient", AccessToken: "a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := newOAuthCredentials(Config{Subdomain: "test", OAuthClientID: "myclient"}, store)
+	if err != nil {
+		t.Fatalf("newOAuthCredentials() error = %v", err)
+	}
+	if creds.ClientID != "myclient" {
+		t.Errorf("ClientID = %s, want myclient", creds.ClientID)
+	}
+}
+
+func TestNewOAuthCredentials_MissingStoredCredential(t *testing.T) {
+	t.Parallel()
+
+	store := NewCredentialStoreWithPath(t.TempDir() + "/credentials.json")
+
+	_, err := newOAuthCredentials(Config{Subdomain: "test"}, store)
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "auth login") {
+		t.Errorf("Expected error to suggest `auth login`, got: %v", err)
+	}
+}

--- a/internal/cli/client_factory_test.go
+++ b/internal/cli/client_factory_test.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/tukaelu/zgsync/internal/zendesk"
 )
@@ -57,6 +61,45 @@ func TestGlobal_NewZendeskClient_AuthTypes(t *testing.T) {
 				t.Errorf("ClientBaseURL() = %s, want https://test.zendesk.com", got)
 			}
 		})
+	}
+}
+
+// setTempHome points the credential store at a temporary home directory and
+// returns a store bound to the credentials.json inside it.
+func setTempHome(t *testing.T) *CredentialStore {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)        // unix
+	t.Setenv("USERPROFILE", home) // windows
+	return NewCredentialStoreWithPath(filepath.Join(home, ".config", "zgsync", "credentials.json"))
+}
+
+func TestGlobal_NewZendeskClient_OAuth(t *testing.T) {
+	store := setTempHome(t)
+	if err := store.Save("test", &StoredCredential{ClientID: "myclient", AccessToken: "access123"}); err != nil {
+		t.Fatal(err)
+	}
+
+	g := &Global{Config: Config{Subdomain: "test", AuthType: AuthTypeOAuth, OAuthClientID: "myclient"}}
+	client, err := g.NewZendeskClient()
+	if err != nil {
+		t.Fatalf("NewZendeskClient() error = %v", err)
+	}
+	if got := zendesk.ClientBaseURL(client); got != "https://test.zendesk.com" {
+		t.Errorf("ClientBaseURL() = %s, want https://test.zendesk.com", got)
+	}
+}
+
+func TestGlobal_NewZendeskClient_OAuthWithoutLogin(t *testing.T) {
+	setTempHome(t)
+
+	g := &Global{Config: Config{Subdomain: "test", AuthType: AuthTypeOAuth, OAuthClientID: "myclient"}}
+	_, err := g.NewZendeskClient()
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "auth login") {
+		t.Errorf("Expected error to suggest `auth login`, got: %v", err)
 	}
 }
 
@@ -120,6 +163,87 @@ func TestNewOAuthCredentials_MatchingClientIDIsAccepted(t *testing.T) {
 	}
 	if creds.ClientID != "myclient" {
 		t.Errorf("ClientID = %s, want myclient", creds.ClientID)
+	}
+}
+
+func TestNewOAuthCredentials_OnRefreshPersistsTokens(t *testing.T) {
+	t.Parallel()
+
+	store := NewCredentialStoreWithPath(filepath.Join(t.TempDir(), "credentials.json"))
+	if err := store.Save("test", &StoredCredential{
+		ClientID:     "myclient",
+		AccessToken:  "old",
+		RefreshToken: "oldrefresh",
+		Scope:        "hc:read",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := newOAuthCredentials(Config{Subdomain: "test"}, store)
+	if err != nil {
+		t.Fatalf("newOAuthCredentials() error = %v", err)
+	}
+
+	// Simulate a login performed while this process is running: OnRefresh
+	// must re-load the file and keep this newer state instead of writing
+	// back the startup-time snapshot.
+	if err := store.Save("test", &StoredCredential{
+		ClientID:     "myclient",
+		AccessToken:  "old",
+		RefreshToken: "oldrefresh",
+		Scope:        "hc:read hc:write",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	expiry := time.Now().Add(30 * time.Minute).Truncate(time.Second)
+	if err := creds.OnRefresh("newaccess", "newrefresh", expiry); err != nil {
+		t.Fatalf("OnRefresh() error = %v", err)
+	}
+
+	saved, err := store.Load("test")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if saved.AccessToken != "newaccess" || saved.RefreshToken != "newrefresh" {
+		t.Errorf("saved tokens = (%s, %s), want (newaccess, newrefresh)", saved.AccessToken, saved.RefreshToken)
+	}
+	if !saved.Expiry.Equal(expiry) {
+		t.Errorf("saved expiry = %v, want %v", saved.Expiry, expiry)
+	}
+	if saved.Scope != "hc:read hc:write" {
+		t.Errorf("saved scope = %s, want hc:read hc:write (the re-loaded state must be kept)", saved.Scope)
+	}
+}
+
+func TestNewOAuthCredentials_OnRefreshSaveFailureIsNotFatal(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("directory permissions are not applicable on Windows")
+	}
+
+	dir := t.TempDir()
+	store := NewCredentialStoreWithPath(filepath.Join(dir, "credentials.json"))
+	if err := store.Save("test", &StoredCredential{ClientID: "myclient", AccessToken: "old", RefreshToken: "oldrefresh"}); err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := newOAuthCredentials(Config{Subdomain: "test"}, store)
+	if err != nil {
+		t.Fatalf("newOAuthCredentials() error = %v", err)
+	}
+
+	// Make the directory read-only so the atomic write fails.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	// Zendesk has already rotated the refresh token at this point; failing
+	// would discard a valid access token, so OnRefresh must warn and return nil.
+	if err := creds.OnRefresh("newaccess", "newrefresh", time.Now().Add(30*time.Minute)); err != nil {
+		t.Errorf("OnRefresh() = %v, want nil despite the save failure", err)
 	}
 }
 

--- a/internal/cli/cmdArchive.go
+++ b/internal/cli/cmdArchive.go
@@ -13,7 +13,11 @@ type CommandArchive struct {
 }
 
 func (c *CommandArchive) AfterApply(g *Global) error {
-	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
+	client, err := g.NewZendeskClient()
+	if err != nil {
+		return err
+	}
+	c.client = client
 	return nil
 }
 

--- a/internal/cli/cmdAuth.go
+++ b/internal/cli/cmdAuth.go
@@ -1,0 +1,181 @@
+package cli
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+	"time"
+
+	"github.com/tukaelu/zgsync/internal/zendesk"
+)
+
+type CommandAuth struct {
+	Login CommandAuthLogin `cmd:"login" help:"Log in to Zendesk via OAuth (authorization code grant with PKCE) and save the tokens locally."`
+}
+
+type CommandAuthLogin struct {
+	Port int `name:"port" help:"Port of the local callback server. The OAuth client must register http://localhost:<port>/callback as a redirect URL." default:"8976"`
+
+	oauthClient *zendesk.OAuthClient
+	credStore   *CredentialStore
+	openBrowser func(string) error
+	timeout     time.Duration
+}
+
+func (c *CommandAuthLogin) AfterApply(g *Global) error {
+	c.oauthClient = zendesk.NewOAuthClient(g.Config.Subdomain)
+	store, err := NewCredentialStore()
+	if err != nil {
+		return err
+	}
+	c.credStore = store
+	c.openBrowser = openBrowser
+	c.timeout = 5 * time.Minute
+	return nil
+}
+
+type callbackResult struct {
+	code string
+	err  error
+}
+
+func (c *CommandAuthLogin) Run(g *Global) error {
+	clientID := g.Config.OAuthClientID
+	if clientID == "" {
+		return fmt.Errorf("oauth_client_id is not set in %s", g.AbsConfig())
+	}
+
+	verifier, err := randomURLSafeString(32)
+	if err != nil {
+		return err
+	}
+	state, err := randomURLSafeString(16)
+	if err != nil {
+		return err
+	}
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", c.Port))
+	if err != nil {
+		return fmt.Errorf("failed to start the callback server: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	redirectURI := fmt.Sprintf("http://localhost:%d/callback", port)
+
+	resultCh := make(chan callbackResult, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		// Ignore requests that are not an OAuth response (prefetch, port scan,
+		// stale tab) and requests with a wrong state, so a stray hit cannot
+		// consume the result slot before the genuine callback arrives.
+		if q.Get("code") == "" && q.Get("error") == "" {
+			http.NotFound(w, r)
+			return
+		}
+		if q.Get("state") != state {
+			http.Error(w, "State mismatch. Retry the login from the terminal.", http.StatusBadRequest)
+			return
+		}
+
+		result := callbackResult{}
+		if errParam := q.Get("error"); errParam != "" {
+			result.err = fmt.Errorf("authorization was denied: %s (%s)", errParam, q.Get("error_description"))
+		} else {
+			result.code = q.Get("code")
+		}
+
+		if result.err != nil {
+			http.Error(w, "Authorization failed. You may close this window and check the terminal.", http.StatusBadRequest)
+		} else {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = fmt.Fprint(w, "<html><body>Authorized. You may close this window and return to the terminal.</body></html>")
+		}
+
+		select {
+		case resultCh <- result:
+		default:
+		}
+	})
+
+	server := &http.Server{Handler: mux}
+	go func() { _ = server.Serve(listener) }()
+	defer func() { _ = server.Close() }()
+
+	authorizeURL := buildAuthorizeURL(fmt.Sprintf(zendesk.BaseURL, g.Config.Subdomain), url.Values{
+		"response_type":         {"code"},
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"scope":                 {g.Config.OAuthScope},
+		"state":                 {state},
+		"code_challenge":        {codeChallengeS256(verifier)},
+		"code_challenge_method": {"S256"},
+	})
+
+	fmt.Printf("Opening the browser to authorize zgsync. If it does not open, visit:\n\n  %s\n\n", authorizeURL)
+	if err := c.openBrowser(authorizeURL); err != nil {
+		fmt.Printf("Failed to open the browser automatically: %v\n", err)
+	}
+
+	var result callbackResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(c.timeout):
+		return fmt.Errorf("timed out waiting for the authorization callback; make sure %s is registered as a redirect URL of the OAuth client", redirectURI)
+	}
+	if result.err != nil {
+		return result.err
+	}
+
+	token, err := c.oauthClient.ExchangeAuthorizationCode(clientID, result.code, redirectURI, verifier)
+	if err != nil {
+		return err
+	}
+
+	cred := &StoredCredential{
+		ClientID:     clientID,
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		Expiry:       token.ExpiryTime(),
+		Scope:        token.Scope,
+	}
+	if err := c.credStore.Save(g.Config.Subdomain, cred); err != nil {
+		return err
+	}
+
+	fmt.Printf("Logged in to %s.zendesk.com. Tokens were saved to %s\n", g.Config.Subdomain, c.credStore.Path())
+	return nil
+}
+
+func buildAuthorizeURL(baseURL string, params url.Values) string {
+	return baseURL + "/oauth/authorizations/new?" + params.Encode()
+}
+
+func randomURLSafeString(byteLen int) (string, error) {
+	b := make([]byte, byteLen)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func codeChallengeS256(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func openBrowser(u string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", u).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", u).Start()
+	default:
+		return exec.Command("xdg-open", u).Start()
+	}
+}

--- a/internal/cli/cmdAuth_test.go
+++ b/internal/cli/cmdAuth_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -232,6 +234,84 @@ func TestCommandAuthLogin_Timeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Errorf("Expected timeout error, got: %v", err)
+	}
+}
+
+// TestCommandAuthLogin_AfterApply verifies that AfterApply wires up the oauth
+// client, credential store, browser opener, and timeout correctly.
+func TestCommandAuthLogin_AfterApply(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	cmd := &CommandAuthLogin{}
+	if err := cmd.AfterApply(authLoginGlobal()); err != nil {
+		t.Fatalf("AfterApply() error = %v", err)
+	}
+	if cmd.oauthClient == nil || cmd.credStore == nil || cmd.openBrowser == nil {
+		t.Error("AfterApply() did not wire up all fields")
+	}
+	if cmd.timeout != 5*time.Minute {
+		t.Errorf("timeout = %v, want 5m", cmd.timeout)
+	}
+}
+
+func TestCommandAuthLogin_BrowserOpenFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"access123","token_type":"bearer","expires_in":1800}`))
+	}))
+	defer tokenServer.Close()
+
+	// Returns an error, but still fires the callback so the login can succeed.
+	browser := func(authorizeURL string) error {
+		u, err := url.Parse(authorizeURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		cb := q.Get("redirect_uri") + "?" + url.Values{
+			"code": {"authcode123"}, "state": {q.Get("state")},
+		}.Encode()
+		go func() {
+			if res, err := http.Get(cb); err == nil {
+				_ = res.Body.Close()
+			}
+		}()
+		return fmt.Errorf("browser not found")
+	}
+
+	cmd, store := newAuthLoginCommand(t, tokenServer.URL, browser)
+	if err := cmd.Run(authLoginGlobal()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if _, err := store.Load("test"); err != nil {
+		t.Errorf("credentials were not saved: %v", err)
+	}
+}
+
+func TestCommandAuthLogin_ListenPortInUse(t *testing.T) {
+	t.Parallel()
+
+	// Keep a listener alive on a known port so Run cannot bind to it.
+	blocker, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = blocker.Close() }()
+	port := blocker.Addr().(*net.TCPAddr).Port
+
+	cmd, _ := newAuthLoginCommand(t, "http://invalid.example.com", func(string) error { return nil })
+	cmd.Port = port
+
+	err = cmd.Run(authLoginGlobal())
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "callback server") {
+		t.Errorf("Expected callback server error, got: %v", err)
 	}
 }
 

--- a/internal/cli/cmdAuth_test.go
+++ b/internal/cli/cmdAuth_test.go
@@ -1,0 +1,252 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tukaelu/zgsync/internal/zendesk"
+)
+
+// browserStub simulates the Zendesk authorization page: it parses the authorize
+// URL and redirects back to the local callback server like a real authorization would.
+func browserStub(t *testing.T, mutate func(q url.Values)) func(string) error {
+	t.Helper()
+	return func(authorizeURL string) error {
+		u, err := url.Parse(authorizeURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+
+		callback := q.Get("redirect_uri") + "?" + url.Values{
+			"code":  {"authcode123"},
+			"state": {q.Get("state")},
+		}.Encode()
+		cu, err := url.Parse(callback)
+		if err != nil {
+			return err
+		}
+		cq := cu.Query()
+		if mutate != nil {
+			mutate(cq)
+		}
+		cu.RawQuery = cq.Encode()
+
+		go func() {
+			res, err := http.Get(cu.String())
+			if err != nil {
+				t.Errorf("callback request failed: %v", err)
+				return
+			}
+			_ = res.Body.Close()
+		}()
+		return nil
+	}
+}
+
+func newAuthLoginCommand(t *testing.T, tokenServerURL string, browser func(string) error) (*CommandAuthLogin, *CredentialStore) {
+	t.Helper()
+	store := NewCredentialStoreWithPath(filepath.Join(t.TempDir(), "credentials.json"))
+	cmd := &CommandAuthLogin{
+		Port:        0,
+		oauthClient: zendesk.NewOAuthClientWithBaseURL("test", tokenServerURL),
+		credStore:   store,
+		openBrowser: browser,
+		timeout:     5 * time.Second,
+	}
+	return cmd, store
+}
+
+func authLoginGlobal() *Global {
+	return &Global{
+		Config: Config{
+			Subdomain:     "test",
+			AuthType:      AuthTypeOAuth,
+			OAuthClientID: "myclient",
+			OAuthScope:    DefaultOAuthScope,
+		},
+	}
+}
+
+func TestCommandAuthLogin_Success(t *testing.T) {
+	t.Parallel()
+
+	var tokenRequest map[string]string
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := map[string]string{}
+		if err := jsonDecode(r, &params); err != nil {
+			t.Errorf("failed to decode token request: %v", err)
+		}
+		tokenRequest = params
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token": "access123",
+			"refresh_token": "refresh456",
+			"token_type": "bearer",
+			"scope": "hc:read hc:write",
+			"expires_in": 1800
+		}`))
+	}))
+	defer tokenServer.Close()
+
+	cmd, store := newAuthLoginCommand(t, tokenServer.URL, browserStub(t, nil))
+
+	if err := cmd.Run(authLoginGlobal()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if tokenRequest["grant_type"] != "authorization_code" {
+		t.Errorf("grant_type = %s, want authorization_code", tokenRequest["grant_type"])
+	}
+	if tokenRequest["code"] != "authcode123" {
+		t.Errorf("code = %s, want authcode123", tokenRequest["code"])
+	}
+	if tokenRequest["code_verifier"] == "" {
+		t.Error("code_verifier is empty; PKCE is not applied")
+	}
+
+	cred, err := store.Load("test")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cred.AccessToken != "access123" || cred.RefreshToken != "refresh456" || cred.ClientID != "myclient" {
+		t.Errorf("stored credential = %+v", cred)
+	}
+	if cred.Expiry.IsZero() {
+		t.Error("stored credential has zero expiry")
+	}
+}
+
+func TestCommandAuthLogin_StateMismatchKeepsWaiting(t *testing.T) {
+	t.Parallel()
+
+	// A callback with a wrong state must not consume the result slot;
+	// with no valid callback arriving, the login times out.
+	cmd, _ := newAuthLoginCommand(t, "http://invalid.example.com", browserStub(t, func(q url.Values) {
+		q.Set("state", "tampered")
+	}))
+	cmd.timeout = 300 * time.Millisecond
+
+	err := cmd.Run(authLoginGlobal())
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("Expected timeout error, got: %v", err)
+	}
+}
+
+func TestCommandAuthLogin_StrayRequestDoesNotAbortLogin(t *testing.T) {
+	t.Parallel()
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token": "access123", "token_type": "bearer", "expires_in": 1800}`))
+	}))
+	defer tokenServer.Close()
+
+	// The browser stub first sends a paramless stray request to /callback,
+	// then the genuine redirect; the login must still succeed.
+	browser := func(authorizeURL string) error {
+		u, err := url.Parse(authorizeURL)
+		if err != nil {
+			return err
+		}
+		q := u.Query()
+		redirectURI := q.Get("redirect_uri")
+
+		go func() {
+			if res, err := http.Get(redirectURI); err == nil {
+				_ = res.Body.Close()
+			}
+			cb := url.Values{"code": {"authcode123"}, "state": {q.Get("state")}}
+			if res, err := http.Get(redirectURI + "?" + cb.Encode()); err == nil {
+				_ = res.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	cmd, store := newAuthLoginCommand(t, tokenServer.URL, browser)
+
+	if err := cmd.Run(authLoginGlobal()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if _, err := store.Load("test"); err != nil {
+		t.Errorf("credentials were not saved: %v", err)
+	}
+}
+
+func TestCommandAuthLogin_AuthorizationDenied(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newAuthLoginCommand(t, "http://invalid.example.com", browserStub(t, func(q url.Values) {
+		q.Del("code")
+		q.Set("error", "access_denied")
+		q.Set("error_description", "The user denied the request")
+	}))
+
+	err := cmd.Run(authLoginGlobal())
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "access_denied") {
+		t.Errorf("Expected access_denied error, got: %v", err)
+	}
+}
+
+func TestCommandAuthLogin_MissingClientID(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newAuthLoginCommand(t, "http://invalid.example.com", browserStub(t, nil))
+
+	g := authLoginGlobal()
+	g.Config.OAuthClientID = ""
+
+	err := cmd.Run(g)
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "oauth_client_id") {
+		t.Errorf("Expected oauth_client_id error, got: %v", err)
+	}
+}
+
+func TestCommandAuthLogin_Timeout(t *testing.T) {
+	t.Parallel()
+
+	cmd, _ := newAuthLoginCommand(t, "http://invalid.example.com", func(string) error {
+		return nil // never hits the callback
+	})
+	cmd.timeout = 100 * time.Millisecond
+
+	err := cmd.Run(authLoginGlobal())
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("Expected timeout error, got: %v", err)
+	}
+}
+
+func TestCodeChallengeS256(t *testing.T) {
+	t.Parallel()
+
+	// test vector from RFC 7636 appendix B
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	expected := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+	if got := codeChallengeS256(verifier); got != expected {
+		t.Errorf("codeChallengeS256() = %s, want %s", got, expected)
+	}
+}
+
+func jsonDecode(r *http.Request, v interface{}) error {
+	defer func() { _ = r.Body.Close() }()
+	return json.NewDecoder(r.Body).Decode(v)
+}

--- a/internal/cli/cmdEmpty.go
+++ b/internal/cli/cmdEmpty.go
@@ -20,7 +20,11 @@ type CommandEmpty struct {
 }
 
 func (c *CommandEmpty) AfterApply(g *Global) error {
-	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
+	client, err := g.NewZendeskClient()
+	if err != nil {
+		return err
+	}
+	c.client = client
 	return nil
 }
 

--- a/internal/cli/cmdPull.go
+++ b/internal/cli/cmdPull.go
@@ -20,7 +20,11 @@ type CommandPull struct {
 }
 
 func (c *CommandPull) AfterApply(g *Global) error {
-	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
+	client, err := g.NewZendeskClient()
+	if err != nil {
+		return err
+	}
+	c.client = client
 	c.converter = converter.NewConverter(false)
 	return nil
 }

--- a/internal/cli/cmdPush.go
+++ b/internal/cli/cmdPush.go
@@ -20,7 +20,11 @@ type CommandPush struct {
 }
 
 func (c *CommandPush) AfterApply(g *Global) error {
-	c.client = zendesk.NewClient(g.Config.Subdomain, g.Config.Email, g.Config.Token)
+	client, err := g.NewZendeskClient()
+	if err != nil {
+		return err
+	}
+	c.client = client
 	c.converter = converter.NewConverter(g.Config.EnableLinkTargetBlank)
 	return nil
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -8,10 +8,23 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	AuthTypeToken             = "token"
+	AuthTypeOAuth             = "oauth"
+	AuthTypeClientCredentials = "client_credentials"
+)
+
+// DefaultOAuthScope restricts tokens to the Help Center API, which is all zgsync needs.
+const DefaultOAuthScope = "hc:read hc:write"
+
 type Config struct {
 	Subdomain                string `yaml:"subdomain" description:"Zendesk subdomain" required:"true"`
-	Email                    string `yaml:"email" description:"Zendesk email" required:"true"`
-	Token                    string `yaml:"token" description:"Zendesk API token" required:"true"`
+	AuthType                 string `yaml:"auth_type" description:"Authentication type (token, oauth, or client_credentials)" default:"token"`
+	Email                    string `yaml:"email" description:"Zendesk email (required for auth_type: token)"`
+	Token                    string `yaml:"token" description:"Zendesk API token (required for auth_type: token)"`
+	OAuthClientID            string `yaml:"oauth_client_id" description:"OAuth client ID (required for auth_type: oauth and client_credentials)"`
+	OAuthClientSecret        string `yaml:"-"` // secret is only accepted via ZGSYNC_OAUTH_CLIENT_SECRET so it never lives in a config file
+	OAuthScope               string `yaml:"oauth_scope" description:"OAuth scope" default:"hc:read hc:write"`
 	DefaultCommentsDisabled  bool   `yaml:"default_comments_disabled" description:"Default comments disabled" default:"false"`
 	DefaultLocale            string `yaml:"default_locale" description:"Default locale for articles" required:"true"`
 	DefaultPermissionGroupID int    `yaml:"default_permission_group_id" description:"Default permission group ID" required:"true"`
@@ -25,11 +38,27 @@ func (c *Config) Validation() error {
 	if c.Subdomain == "" {
 		return fmt.Errorf("subdomain is required")
 	}
-	if c.Email == "" {
-		return fmt.Errorf("email is required")
-	}
-	if c.Token == "" {
-		return fmt.Errorf("token is required")
+	switch c.AuthType {
+	case "", AuthTypeToken:
+		if c.Email == "" {
+			return fmt.Errorf("email is required")
+		}
+		if c.Token == "" {
+			return fmt.Errorf("token is required")
+		}
+	case AuthTypeOAuth:
+		if c.OAuthClientID == "" {
+			return fmt.Errorf("oauth_client_id is required for auth_type: oauth")
+		}
+	case AuthTypeClientCredentials:
+		if c.OAuthClientID == "" {
+			return fmt.Errorf("oauth_client_id is required for auth_type: client_credentials")
+		}
+		if c.OAuthClientSecret == "" {
+			return fmt.Errorf("the ZGSYNC_OAUTH_CLIENT_SECRET environment variable is required for auth_type: client_credentials")
+		}
+	default:
+		return fmt.Errorf("auth_type must be one of %s, %s, or %s", AuthTypeToken, AuthTypeOAuth, AuthTypeClientCredentials)
 	}
 	if c.DefaultLocale == "" {
 		return fmt.Errorf("default_locale is required")
@@ -40,14 +69,65 @@ func (c *Config) Validation() error {
 	return nil
 }
 
+// applyDefaultsAndEnv fills in default values and applies environment variable
+// overrides so that secrets can be injected via CI secrets instead of the config file.
+func (c *Config) applyDefaultsAndEnv() {
+	if c.AuthType == "" {
+		c.AuthType = AuthTypeToken
+	}
+	if c.OAuthScope == "" {
+		c.OAuthScope = DefaultOAuthScope
+	}
+	if v := os.Getenv("ZGSYNC_OAUTH_CLIENT_ID"); v != "" {
+		c.OAuthClientID = v
+	}
+	if v := os.Getenv("ZGSYNC_OAUTH_CLIENT_SECRET"); v != "" {
+		c.OAuthClientSecret = v
+	}
+}
+
+// zgsyncConfigDir is the single source of the config directory path, shared
+// with the credential store so the two files can never end up in different places.
+func zgsyncConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "zgsync"), nil
+}
+
 func (g *Global) LoadConfig() error {
+	if err := g.readConfigFile(); err != nil {
+		return err
+	}
+	return g.Config.Validation()
+}
+
+// LoadConfigForAuthLogin loads the config but only validates what `auth login`
+// actually needs. Content settings and other auth types' requirements (API
+// tokens, the client_credentials secret) are irrelevant to logging in, and
+// requiring them would block users migrating to OAuth.
+func (g *Global) LoadConfigForAuthLogin() error {
+	if err := g.readConfigFile(); err != nil {
+		return err
+	}
+	if g.Config.Subdomain == "" {
+		return fmt.Errorf("subdomain is required")
+	}
+	return nil
+}
+
+func (g *Global) readConfigFile() error {
 	if g.ConfigPath == "" {
-		home, _ := os.UserHomeDir()
-		g.ConfigPath = filepath.Join(home, ".config", "zgsync", "config.yaml")
+		dir, err := zgsyncConfigDir()
+		if err != nil {
+			return err
+		}
+		g.ConfigPath = filepath.Join(dir, "config.yaml")
 	}
 	b, err := os.ReadFile(g.ConfigPath)
 	if err != nil {
-		return nil
+		return fmt.Errorf("failed to read config file %s: %w", g.ConfigPath, err)
 	}
 	if err := yaml.Unmarshal(b, &g.Config); err != nil {
 		return err
@@ -55,7 +135,8 @@ func (g *Global) LoadConfig() error {
 	if g.Config.ContentsDir == "" {
 		g.Config.ContentsDir = "."
 	}
-	return g.Config.Validation()
+	g.Config.applyDefaultsAndEnv()
+	return nil
 }
 
 func (g *Global) ConfigExists() error {

--- a/internal/cli/config_auth_test.go
+++ b/internal/cli/config_auth_test.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestConfig_Validation_AuthTypes(t *testing.T) {
+	base := Config{
+		Subdomain:                "test",
+		DefaultLocale:            "en",
+		DefaultPermissionGroupID: 123,
+	}
+
+	tests := []struct {
+		name      string
+		mutate    func(*Config)
+		expectErr string
+	}{
+		{
+			name: "oauth requires client id",
+			mutate: func(c *Config) {
+				c.AuthType = AuthTypeOAuth
+			},
+			expectErr: "oauth_client_id",
+		},
+		{
+			name: "oauth with client id is valid",
+			mutate: func(c *Config) {
+				c.AuthType = AuthTypeOAuth
+				c.OAuthClientID = "myclient"
+			},
+		},
+		{
+			name: "client_credentials requires client id",
+			mutate: func(c *Config) {
+				c.AuthType = AuthTypeClientCredentials
+				c.OAuthClientSecret = "secret"
+			},
+			expectErr: "oauth_client_id",
+		},
+		{
+			name: "client_credentials requires client secret",
+			mutate: func(c *Config) {
+				c.AuthType = AuthTypeClientCredentials
+				c.OAuthClientID = "myclient"
+			},
+			expectErr: "ZGSYNC_OAUTH_CLIENT_SECRET",
+		},
+		{
+			name: "client_credentials with id and secret is valid",
+			mutate: func(c *Config) {
+				c.AuthType = AuthTypeClientCredentials
+				c.OAuthClientID = "myclient"
+				c.OAuthClientSecret = "secret"
+			},
+		},
+		{
+			name: "unknown auth_type is rejected",
+			mutate: func(c *Config) {
+				c.AuthType = "bogus"
+			},
+			expectErr: "auth_type",
+		},
+		{
+			name: "empty auth_type falls back to token and requires email",
+			mutate: func(c *Config) {
+				c.Token = "token123"
+			},
+			expectErr: "email",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base
+			tt.mutate(&cfg)
+
+			err := cfg.Validation()
+			if tt.expectErr == "" {
+				if err != nil {
+					t.Errorf("Validation() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validation() = nil, want error containing %q", tt.expectErr)
+			}
+			if !strings.Contains(err.Error(), tt.expectErr) {
+				t.Errorf("Validation() error = %v, want error containing %q", err, tt.expectErr)
+			}
+		})
+	}
+}
+
+func TestConfig_ApplyDefaultsAndEnv(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		cfg := Config{}
+		cfg.applyDefaultsAndEnv()
+
+		if cfg.AuthType != AuthTypeToken {
+			t.Errorf("AuthType = %s, want %s", cfg.AuthType, AuthTypeToken)
+		}
+		if cfg.OAuthScope != DefaultOAuthScope {
+			t.Errorf("OAuthScope = %s, want %s", cfg.OAuthScope, DefaultOAuthScope)
+		}
+	})
+
+	t.Run("env overrides client id and secret", func(t *testing.T) {
+		t.Setenv("ZGSYNC_OAUTH_CLIENT_ID", "env-client")
+		t.Setenv("ZGSYNC_OAUTH_CLIENT_SECRET", "env-secret")
+
+		cfg := Config{OAuthClientID: "file-client", OAuthClientSecret: "file-secret"}
+		cfg.applyDefaultsAndEnv()
+
+		if cfg.OAuthClientID != "env-client" {
+			t.Errorf("OAuthClientID = %s, want env-client", cfg.OAuthClientID)
+		}
+		if cfg.OAuthClientSecret != "env-secret" {
+			t.Errorf("OAuthClientSecret = %s, want env-secret", cfg.OAuthClientSecret)
+		}
+	})
+
+	t.Run("file values kept without env", func(t *testing.T) {
+		cfg := Config{OAuthClientID: "file-client", OAuthScope: "hc:read"}
+		cfg.applyDefaultsAndEnv()
+
+		if cfg.OAuthClientID != "file-client" {
+			t.Errorf("OAuthClientID = %s, want file-client", cfg.OAuthClientID)
+		}
+		if cfg.OAuthScope != "hc:read" {
+			t.Errorf("OAuthScope = %s, want hc:read", cfg.OAuthScope)
+		}
+	})
+}
+
+func TestConfig_OAuthClientSecretIgnoredInYAML(t *testing.T) {
+	t.Parallel()
+
+	var cfg Config
+	if err := yaml.Unmarshal([]byte("oauth_client_secret: leaked-secret"), &cfg); err != nil {
+		t.Fatalf("yaml.Unmarshal() error = %v", err)
+	}
+	if cfg.OAuthClientSecret != "" {
+		t.Errorf("OAuthClientSecret = %s, want empty (must only be set via env)", cfg.OAuthClientSecret)
+	}
+}

--- a/internal/cli/config_auth_test.go
+++ b/internal/cli/config_auth_test.go
@@ -136,6 +136,61 @@ func TestConfig_ApplyDefaultsAndEnv(t *testing.T) {
 	})
 }
 
+func TestLoadConfigForAuthLogin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("subdomain-only config is sufficient", func(t *testing.T) {
+		t.Parallel()
+
+		g := &Global{ConfigPath: "testdata/config_subdomain_only.yaml"}
+		if err := g.LoadConfigForAuthLogin(); err != nil {
+			t.Fatalf("LoadConfigForAuthLogin() error = %v", err)
+		}
+		if g.Config.Subdomain != "example" {
+			t.Errorf("Subdomain = %s, want example", g.Config.Subdomain)
+		}
+	})
+
+	t.Run("the same subdomain-only config is rejected by LoadConfig", func(t *testing.T) {
+		t.Parallel()
+
+		// This contrast is the reason LoadConfigForAuthLogin exists: a user
+		// migrating to OAuth has no API token yet, so `auth login` must not
+		// go through the full validation. If this case starts passing,
+		// the lenient loader can be removed.
+		g := &Global{ConfigPath: "testdata/config_subdomain_only.yaml"}
+		if err := g.LoadConfig(); err == nil {
+			t.Error("LoadConfig() = nil, want validation error for a subdomain-only config")
+		}
+	})
+
+	t.Run("missing subdomain is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		g := &Global{ConfigPath: "testdata/config_no_subdomain.yaml"}
+		err := g.LoadConfigForAuthLogin()
+		if err == nil {
+			t.Fatal("Expected error but got none")
+		}
+		if !strings.Contains(err.Error(), "subdomain") {
+			t.Errorf("Expected subdomain error, got: %v", err)
+		}
+	})
+
+	t.Run("missing config file is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		g := &Global{ConfigPath: "testdata/non-existent.yaml"}
+		err := g.LoadConfigForAuthLogin()
+		if err == nil {
+			t.Fatal("Expected error but got none")
+		}
+		if !strings.Contains(err.Error(), "failed to read config file") {
+			t.Errorf("Expected read error, got: %v", err)
+		}
+	})
+}
+
 func TestConfig_OAuthClientSecretIgnoredInYAML(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -109,12 +109,10 @@ func TestLoadConfig_ErrorCases(t *testing.T) {
 		errMsg     string
 	}{
 		{
-			// Note: Although this test is in TestLoadConfig_ErrorCases, this case does NOT
-			// produce an error. LoadConfig intentionally returns nil when os.ReadFile() fails
-			// (e.g. file not found), treating a missing config file as a no-op.
-			name:       "non-existent config file is silently ignored",
+			name:       "non-existent config file",
 			configPath: "testdata/non-existent.yaml",
-			expectErr:  false, // LoadConfig returns nil for missing files
+			expectErr:  true,
+			errMsg:     "failed to read config file",
 		},
 		{
 			name:       "invalid yaml format",
@@ -293,7 +291,7 @@ func TestConfig_CLIIntegrationErrors(t *testing.T) {
 		description string
 	}{
 		{
-			name: "config file with permission denied is silently ignored",
+			name: "config file with permission denied",
 			setupConfig: func() string {
 				configFile := filepath.Join(tempDir, "restricted-config.yaml")
 				configContent := `subdomain: test
@@ -314,16 +312,16 @@ default_permission_group_id: 123`
 
 				return configFile
 			},
-			expectError: false, // LoadConfig is lenient about missing/inaccessible files
-			description: "LoadConfig should handle permission errors gracefully",
+			expectError: true,
+			description: "An unreadable config must fail instead of running with a zero-value config",
 		},
 		{
 			name: "config file in non-existent directory",
 			setupConfig: func() string {
 				return "/non/existent/directory/config.yaml"
 			},
-			expectError: false, // LoadConfig returns nil for missing files
-			description: "Should handle non-existent config file gracefully",
+			expectError: true,
+			description: "A missing config must fail instead of running with a zero-value config",
 		},
 		{
 			name: "corrupted config file",
@@ -354,7 +352,7 @@ default_permission_group_id: "not_a_number"
 
 			// Restore permissions for cleanup if needed
 			defer func() {
-				if tt.name == "config file with permission denied is silently ignored" {
+				if tt.name == "config file with permission denied" {
 					_ = os.Chmod(configPath, 0644)
 				}
 			}()

--- a/internal/cli/credstore.go
+++ b/internal/cli/credstore.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// StoredCredential holds the OAuth tokens saved by `zgsync auth login`.
+type StoredCredential struct {
+	ClientID     string    `json:"client_id"`
+	AccessToken  string    `json:"access_token"`
+	RefreshToken string    `json:"refresh_token,omitempty"`
+	Expiry       time.Time `json:"expiry,omitempty"`
+	Scope        string    `json:"scope,omitempty"`
+}
+
+// CredentialStore reads and writes OAuth tokens in a JSON file keyed by subdomain.
+// The file is managed exclusively by zgsync and kept separate from config.yaml
+// so that tokens never end up in a user-edited (and possibly committed) file.
+type CredentialStore struct {
+	path string
+}
+
+func NewCredentialStore() (*CredentialStore, error) {
+	dir, err := zgsyncConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	return &CredentialStore{
+		path: filepath.Join(dir, "credentials.json"),
+	}, nil
+}
+
+func NewCredentialStoreWithPath(path string) *CredentialStore {
+	return &CredentialStore{path: path}
+}
+
+func (s *CredentialStore) Path() string {
+	return s.path
+}
+
+func (s *CredentialStore) Load(subdomain string) (*StoredCredential, error) {
+	creds, err := s.loadAll()
+	if err != nil {
+		return nil, err
+	}
+	cred, ok := creds[subdomain]
+	if !ok {
+		return nil, fmt.Errorf("no credentials found for subdomain %q in %s; run `zgsync auth login` first", subdomain, s.path)
+	}
+	return &cred, nil
+}
+
+func (s *CredentialStore) Save(subdomain string, cred *StoredCredential) error {
+	creds, err := s.loadAll()
+	if err != nil {
+		return err
+	}
+	creds[subdomain] = *cred
+
+	b, err := json.MarshalIndent(creds, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
+		return err
+	}
+	return s.writeAtomic(b)
+}
+
+// writeAtomic writes via a temp file and rename so a crash mid-write can
+// never leave a truncated credentials.json that would brick every subdomain.
+func (s *CredentialStore) writeAtomic(b []byte) error {
+	tmp, err := os.CreateTemp(filepath.Dir(s.path), ".credentials-*.json")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+
+	if _, err := tmp.Write(b); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), s.path)
+}
+
+func (s *CredentialStore) loadAll() (map[string]StoredCredential, error) {
+	creds := map[string]StoredCredential{}
+	b, err := os.ReadFile(s.path)
+	if os.IsNotExist(err) {
+		return creds, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &creds); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", s.path, err)
+	}
+	return creds, nil
+}

--- a/internal/cli/credstore_test.go
+++ b/internal/cli/credstore_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCredentialStore_SaveAndLoad(t *testing.T) {
+	t.Parallel()
+
+	store := NewCredentialStoreWithPath(filepath.Join(t.TempDir(), "credentials.json"))
+
+	cred := &StoredCredential{
+		ClientID:     "myclient",
+		AccessToken:  "access123",
+		RefreshToken: "refresh456",
+		Expiry:       time.Now().Add(30 * time.Minute).Truncate(time.Second),
+		Scope:        "hc:read hc:write",
+	}
+	if err := store.Save("mycompany", cred); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	loaded, err := store.Load("mycompany")
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if loaded.ClientID != cred.ClientID ||
+		loaded.AccessToken != cred.AccessToken ||
+		loaded.RefreshToken != cred.RefreshToken ||
+		loaded.Scope != cred.Scope ||
+		!loaded.Expiry.Equal(cred.Expiry) {
+		t.Errorf("Load() = %+v, want %+v", loaded, cred)
+	}
+}
+
+func TestCredentialStore_SavePreservesOtherSubdomains(t *testing.T) {
+	t.Parallel()
+
+	store := NewCredentialStoreWithPath(filepath.Join(t.TempDir(), "credentials.json"))
+
+	if err := store.Save("company-a", &StoredCredential{ClientID: "a", AccessToken: "tokena"}); err != nil {
+		t.Fatalf("Save(company-a) error = %v", err)
+	}
+	if err := store.Save("company-b", &StoredCredential{ClientID: "b", AccessToken: "tokenb"}); err != nil {
+		t.Fatalf("Save(company-b) error = %v", err)
+	}
+
+	credA, err := store.Load("company-a")
+	if err != nil {
+		t.Fatalf("Load(company-a) error = %v", err)
+	}
+	if credA.AccessToken != "tokena" {
+		t.Errorf("Load(company-a).AccessToken = %s, want tokena", credA.AccessToken)
+	}
+}
+
+func TestCredentialStore_LoadMissingSubdomain(t *testing.T) {
+	t.Parallel()
+
+	store := NewCredentialStoreWithPath(filepath.Join(t.TempDir(), "credentials.json"))
+
+	_, err := store.Load("unknown")
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "auth login") {
+		t.Errorf("Expected error to suggest `auth login`, got: %v", err)
+	}
+}
+
+func TestCredentialStore_FilePermissions(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("file permissions are not applicable on Windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "nested", "credentials.json")
+	store := NewCredentialStoreWithPath(path)
+
+	if err := store.Save("mycompany", &StoredCredential{ClientID: "c", AccessToken: "t"}); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("credentials.json permission = %o, want 600", perm)
+	}
+}
+
+func TestCredentialStore_LoadBrokenFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(path, []byte("{broken json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := NewCredentialStoreWithPath(path)
+
+	_, err := store.Load("mycompany")
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "failed to parse") {
+		t.Errorf("Expected parse error, got: %v", err)
+	}
+}

--- a/internal/cli/credstore_test.go
+++ b/internal/cli/credstore_test.go
@@ -9,6 +9,24 @@ import (
 	"time"
 )
 
+func TestCredentialStore_SaveWithBrokenFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "credentials.json")
+	if err := os.WriteFile(path, []byte("{broken json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store := NewCredentialStoreWithPath(path)
+
+	err := store.Save("test", &StoredCredential{AccessToken: "a"})
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "failed to parse") {
+		t.Errorf("Expected parse error, got: %v", err)
+	}
+}
+
 func TestCredentialStore_SaveAndLoad(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/testdata/config_no_subdomain.yaml
+++ b/internal/cli/testdata/config_no_subdomain.yaml
@@ -1,0 +1,2 @@
+default_locale: ja
+default_permission_group_id: 123

--- a/internal/cli/testdata/config_subdomain_only.yaml
+++ b/internal/cli/testdata/config_subdomain_only.yaml
@@ -1,0 +1,1 @@
+subdomain: example

--- a/internal/zendesk/client.go
+++ b/internal/zendesk/client.go
@@ -1,11 +1,12 @@
 package zendesk
 
 import (
-	"encoding/base64"
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	_ "github.com/tukaelu/zgsync/internal/zendesk/httplog"
 )
@@ -13,6 +14,17 @@ import (
 const (
 	BaseURL = "https://%s.zendesk.com"
 )
+
+// httpClient is shared by API and OAuth token requests so a black-holed
+// endpoint fails instead of blocking the CLI forever.
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
+func resolveBaseURL(subdomain, override string) string {
+	if override != "" {
+		return override
+	}
+	return fmt.Sprintf(BaseURL, subdomain)
+}
 
 type Client interface {
 	CreateArticle(locale string, sectionID int, payload string) (string, error)
@@ -26,16 +38,18 @@ type Client interface {
 
 type clientImpl struct {
 	subdomain       string
-	email           string
-	token           string
+	creds           Credentials
 	baseURLOverride string
 }
 
 func NewClient(subdomain, email, token string) Client {
+	return NewClientWithCredentials(subdomain, &TokenCredentials{Email: email, Token: token})
+}
+
+func NewClientWithCredentials(subdomain string, creds Credentials) Client {
 	return &clientImpl{
 		subdomain: subdomain,
-		email:     email,
-		token:     token,
+		creds:     creds,
 	}
 }
 
@@ -118,69 +132,77 @@ func (c *clientImpl) ShowTranslation(articleID int, locale string) (string, erro
 }
 
 func (c *clientImpl) doRequest(method string, endpoint string, payload io.Reader) (string, error) {
-	if endpoint == "" {
-		return "", fmt.Errorf("endpoint is required")
-	}
-	reqURL := c.baseURL() + endpoint
-	req, err := http.NewRequest(method, reqURL, payload)
-	if err != nil {
-		return "", err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Basic "+c.authorizationToken())
-
-	client := &http.Client{}
-	res, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = res.Body.Close() }()
-
-	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
-		return "", fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
-
-	resPayload, err := io.ReadAll(res.Body)
-	if err != nil {
-		return "", err
-	}
-	return string(resPayload), nil
+	return c.do(method, endpoint, payload, http.StatusOK, http.StatusCreated)
 }
 
 func (c *clientImpl) doDeleteRequest(endpoint string) error {
+	_, err := c.do(http.MethodDelete, endpoint, nil, http.StatusNoContent)
+	return err
+}
+
+func (c *clientImpl) do(method, endpoint string, payload io.Reader, okStatuses ...int) (string, error) {
 	if endpoint == "" {
-		return fmt.Errorf("endpoint is required")
+		return "", fmt.Errorf("endpoint is required")
 	}
-	reqURL := c.baseURL() + endpoint
-	req, err := http.NewRequest(http.MethodDelete, reqURL, nil)
-	if err != nil {
-		return err
+	var body []byte
+	if payload != nil {
+		var err error
+		if body, err = io.ReadAll(payload); err != nil {
+			return "", err
+		}
 	}
 
+	status, resBody, err := c.attempt(method, endpoint, body)
+	if err != nil {
+		return "", err
+	}
+	// A 401 despite a locally valid token means it was revoked or expired
+	// server-side; discard the cached token and retry once so the OAuth
+	// refresh/token flow can recover.
+	if status == http.StatusUnauthorized {
+		if inv, ok := c.creds.(interface{ Invalidate() }); ok {
+			inv.Invalidate()
+			if status, resBody, err = c.attempt(method, endpoint, body); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	for _, ok := range okStatuses {
+		if status == ok {
+			return string(resBody), nil
+		}
+	}
+	return "", fmt.Errorf("unexpected status code: %d", status)
+}
+
+func (c *clientImpl) attempt(method, endpoint string, body []byte) (int, []byte, error) {
+	req, err := http.NewRequest(method, c.baseURL()+endpoint, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, err
+	}
+
+	authz, err := c.creds.AuthorizationHeader()
+	if err != nil {
+		return 0, nil, err
+	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Basic "+c.authorizationToken())
+	req.Header.Set("Authorization", authz)
 
-	client := &http.Client{}
-	res, err := client.Do(req)
+	res, err := httpClient.Do(req)
 	if err != nil {
-		return err
+		return 0, nil, err
 	}
 	defer func() { _ = res.Body.Close() }()
 
-	if res.StatusCode != http.StatusNoContent {
-		return fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return 0, nil, err
 	}
-	return nil
+	return res.StatusCode, resBody, nil
 }
 
 func (c *clientImpl) baseURL() string {
-	if c.baseURLOverride != "" {
-		return c.baseURLOverride
-	}
-	return fmt.Sprintf(BaseURL, c.subdomain)
+	return resolveBaseURL(c.subdomain, c.baseURLOverride)
 }
 
-func (c *clientImpl) authorizationToken() string {
-	return base64.StdEncoding.EncodeToString([]byte(c.email + ":" + c.token))
-}

--- a/internal/zendesk/client_test.go
+++ b/internal/zendesk/client_test.go
@@ -31,17 +31,19 @@ func TestClientImpl_BaseURL(t *testing.T) {
 	}
 }
 
-func TestClientImpl_AuthorizationToken(t *testing.T) {
+func TestTokenCredentials_AuthorizationHeader(t *testing.T) {
 	t.Parallel()
 
-	client := NewClient("test", "user@example.com/token", "secrettoken")
-	impl := client.(*clientImpl)
+	creds := &TokenCredentials{Email: "user@example.com/token", Token: "secrettoken"}
 
-	expected := "dXNlckBleGFtcGxlLmNvbS90b2tlbjpzZWNyZXR0b2tlbg=="
-	actual := impl.authorizationToken()
+	expected := "Basic dXNlckBleGFtcGxlLmNvbS90b2tlbjpzZWNyZXR0b2tlbg=="
+	actual, err := creds.AuthorizationHeader()
+	if err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
 
 	if actual != expected {
-		t.Errorf("authorizationToken() = %s, want %s", actual, expected)
+		t.Errorf("AuthorizationHeader() = %s, want %s", actual, expected)
 	}
 }
 
@@ -50,8 +52,7 @@ func TestClientImpl_DoRequest_EmptyEndpoint(t *testing.T) {
 
 	client := &clientImpl{
 		subdomain: "test",
-		email:     "test@example.com/token",
-		token:     "testtoken",
+		creds:     &TokenCredentials{Email: "test@example.com/token", Token: "testtoken"},
 	}
 
 	_, err := client.doRequest("GET", "", nil)
@@ -64,8 +65,7 @@ func TestClientImpl_DoRequest_EmptyEndpoint(t *testing.T) {
 func newTestClientImpl(serverURL string) *clientImpl {
 	return &clientImpl{
 		subdomain:       "test",
-		email:           "test@example.com/token",
-		token:           "testtoken",
+		creds:           &TokenCredentials{Email: "test@example.com/token", Token: "testtoken"},
 		baseURLOverride: serverURL,
 	}
 }
@@ -842,10 +842,13 @@ func TestClientImpl_RealHTTPClient(t *testing.T) {
 			t.Errorf("Expected baseURL %s, got %s", expectedBaseURL, baseURL)
 		}
 
-		authToken := realClient.authorizationToken()
-		expectedToken := base64.StdEncoding.EncodeToString([]byte("test@example.com/token:testtoken"))
-		if authToken != expectedToken {
-			t.Errorf("Expected authToken %s, got %s", expectedToken, authToken)
+		authz, err := realClient.creds.AuthorizationHeader()
+		if err != nil {
+			t.Fatalf("AuthorizationHeader() error = %v", err)
+		}
+		expectedAuthz := "Basic " + base64.StdEncoding.EncodeToString([]byte("test@example.com/token:testtoken"))
+		if authz != expectedAuthz {
+			t.Errorf("Expected authorization header %s, got %s", expectedAuthz, authz)
 		}
 	})
 
@@ -931,8 +934,7 @@ func TestClient_AuthenticationErrors(t *testing.T) {
 
 			client := &clientImpl{
 				subdomain:       "test",
-				email:           tt.email,
-				token:           tt.token,
+				creds:           &TokenCredentials{Email: tt.email, Token: tt.token},
 				baseURLOverride: server.URL,
 			}
 
@@ -1007,9 +1009,12 @@ func TestClient_AuthorizationHeaderGeneration(t *testing.T) {
 			client := NewClient("test", tt.email, tt.token)
 			impl := client.(*clientImpl)
 
-			actualHeader := impl.authorizationToken()
+			actualHeader, err := impl.creds.AuthorizationHeader()
+			if err != nil {
+				t.Fatalf("AuthorizationHeader() error = %v", err)
+			}
 
-			if actualHeader != tt.expectedHeader {
+			if actualHeader != "Basic "+tt.expectedHeader {
 				t.Errorf("Authorization header mismatch for %s", tt.name)
 				t.Errorf("Expected: %s", tt.expectedHeader)
 				t.Errorf("Actual:   %s", actualHeader)
@@ -1030,8 +1035,7 @@ func TestClient_AllMethods_AuthenticationFailure(t *testing.T) {
 
 	client := &clientImpl{
 		subdomain:       "test",
-		email:           "invalid@example.com/token",
-		token:           "invalidtoken",
+		creds:           &TokenCredentials{Email: "invalid@example.com/token", Token: "invalidtoken"},
 		baseURLOverride: server.URL,
 	}
 
@@ -1184,8 +1188,7 @@ func TestClientImpl_ArchiveArticle(t *testing.T) {
 
 			client := &clientImpl{
 				subdomain:       "test",
-				email:           "test@example.com/token",
-				token:           "testtoken",
+				creds:           &TokenCredentials{Email: "test@example.com/token", Token: "testtoken"},
 				baseURLOverride: server.URL,
 			}
 
@@ -1206,8 +1209,7 @@ func TestClientImpl_DoDeleteRequest_EmptyEndpoint(t *testing.T) {
 
 	client := &clientImpl{
 		subdomain: "test",
-		email:     "test@example.com/token",
-		token:     "testtoken",
+		creds:     &TokenCredentials{Email: "test@example.com/token", Token: "testtoken"},
 	}
 
 	err := client.doDeleteRequest("")

--- a/internal/zendesk/credentials.go
+++ b/internal/zendesk/credentials.go
@@ -1,0 +1,113 @@
+package zendesk
+
+import (
+	"encoding/base64"
+	"fmt"
+	"time"
+)
+
+// tokenExpiryMargin is subtracted from the token lifetime (see
+// OAuthTokenResponse.ExpiryTime) so that a token close to expiration is not
+// used for a request that may outlive it.
+const tokenExpiryMargin = 60 * time.Second
+
+// tokenExpired reports whether a token with the given expiry can no longer be
+// used. A zero expiry means the token does not expire.
+func tokenExpired(expiry time.Time) bool {
+	return !expiry.IsZero() && !time.Now().Before(expiry)
+}
+
+// Credentials provides the value of the Authorization header for API requests.
+type Credentials interface {
+	AuthorizationHeader() (string, error)
+}
+
+// TokenCredentials authenticates with a Zendesk API token using Basic authentication.
+// refs: https://developer.zendesk.com/api-reference/introduction/security-and-auth/#api-token
+type TokenCredentials struct {
+	Email string
+	Token string
+}
+
+func (c *TokenCredentials) AuthorizationHeader() (string, error) {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(c.Email+":"+c.Token)), nil
+}
+
+// OAuthCredentials authenticates with an OAuth access token obtained via the
+// authorization_code grant, refreshing it automatically when expired.
+type OAuthCredentials struct {
+	AccessToken  string
+	RefreshToken string
+	Expiry       time.Time
+	ClientID     string
+	OAuth        *OAuthClient
+	// OnRefresh is called after a successful refresh so the caller can persist the new tokens.
+	OnRefresh func(accessToken, refreshToken string, expiry time.Time) error
+}
+
+func (c *OAuthCredentials) AuthorizationHeader() (string, error) {
+	if c.AccessToken == "" || tokenExpired(c.Expiry) {
+		if err := c.refresh(); err != nil {
+			return "", err
+		}
+	}
+	return "Bearer " + c.AccessToken, nil
+}
+
+// Invalidate discards the cached access token so the next request refreshes it.
+// The API client calls this when a request comes back 401, which means the
+// token was revoked or expired server-side despite a valid local expiry.
+func (c *OAuthCredentials) Invalidate() {
+	c.AccessToken = ""
+}
+
+func (c *OAuthCredentials) refresh() error {
+	if c.RefreshToken == "" {
+		return fmt.Errorf("the access token is expired and no refresh token is available; run `zgsync auth login` again")
+	}
+	res, err := c.OAuth.RefreshToken(c.ClientID, c.RefreshToken)
+	if err != nil {
+		return fmt.Errorf("failed to refresh the access token; run `zgsync auth login` again: %w", err)
+	}
+	c.AccessToken = res.AccessToken
+	if res.RefreshToken != "" {
+		c.RefreshToken = res.RefreshToken
+	}
+	c.Expiry = res.ExpiryTime()
+	if c.OnRefresh != nil {
+		if err := c.OnRefresh(c.AccessToken, c.RefreshToken, c.Expiry); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ClientCredentialsProvider obtains an access token via the client_credentials
+// grant on demand and caches it in memory for the lifetime of the process.
+// Intended for non-interactive environments such as CI.
+type ClientCredentialsProvider struct {
+	ClientID     string
+	ClientSecret string
+	Scope        string
+	OAuth        *OAuthClient
+
+	accessToken string
+	expiry      time.Time
+}
+
+func (c *ClientCredentialsProvider) AuthorizationHeader() (string, error) {
+	if c.accessToken == "" || tokenExpired(c.expiry) {
+		res, err := c.OAuth.ClientCredentials(c.ClientID, c.ClientSecret, c.Scope)
+		if err != nil {
+			return "", err
+		}
+		c.accessToken = res.AccessToken
+		c.expiry = res.ExpiryTime()
+	}
+	return "Bearer " + c.accessToken, nil
+}
+
+// Invalidate discards the cached access token so the next request fetches a new one.
+func (c *ClientCredentialsProvider) Invalidate() {
+	c.accessToken = ""
+}

--- a/internal/zendesk/credentials_test.go
+++ b/internal/zendesk/credentials_test.go
@@ -1,0 +1,326 @@
+package zendesk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestOAuthCredentials_AuthorizationHeader_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	creds := &OAuthCredentials{
+		AccessToken: "validtoken",
+		Expiry:      time.Now().Add(1 * time.Hour),
+	}
+
+	authz, err := creds.AuthorizationHeader()
+	if err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
+	if authz != "Bearer validtoken" {
+		t.Errorf("AuthorizationHeader() = %s, want Bearer validtoken", authz)
+	}
+}
+
+func TestOAuthCredentials_AuthorizationHeader_NoExpiry(t *testing.T) {
+	t.Parallel()
+
+	creds := &OAuthCredentials{AccessToken: "legacytoken"}
+
+	authz, err := creds.AuthorizationHeader()
+	if err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
+	if authz != "Bearer legacytoken" {
+		t.Errorf("AuthorizationHeader() = %s, want Bearer legacytoken", authz)
+	}
+}
+
+func TestOAuthCredentials_AuthorizationHeader_RefreshesExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token": "refreshedtoken",
+			"refresh_token": "newrefresh",
+			"token_type": "bearer",
+			"expires_in": 1800
+		}`))
+	}))
+	defer server.Close()
+
+	var savedAccess, savedRefresh string
+	var savedExpiry time.Time
+	creds := &OAuthCredentials{
+		AccessToken:  "expiredtoken",
+		RefreshToken: "oldrefresh",
+		Expiry:       time.Now().Add(-1 * time.Minute),
+		ClientID:     "myclient",
+		OAuth:        &OAuthClient{subdomain: "test", baseURLOverride: server.URL},
+		OnRefresh: func(accessToken, refreshToken string, expiry time.Time) error {
+			savedAccess = accessToken
+			savedRefresh = refreshToken
+			savedExpiry = expiry
+			return nil
+		},
+	}
+
+	authz, err := creds.AuthorizationHeader()
+	if err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
+	if authz != "Bearer refreshedtoken" {
+		t.Errorf("AuthorizationHeader() = %s, want Bearer refreshedtoken", authz)
+	}
+	if savedAccess != "refreshedtoken" || savedRefresh != "newrefresh" {
+		t.Errorf("OnRefresh received (%s, %s), want (refreshedtoken, newrefresh)", savedAccess, savedRefresh)
+	}
+	if savedExpiry.IsZero() {
+		t.Error("OnRefresh received zero expiry")
+	}
+}
+
+func TestOAuthCredentials_AuthorizationHeader_ExpiredWithoutRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	creds := &OAuthCredentials{
+		AccessToken: "expiredtoken",
+		Expiry:      time.Now().Add(-1 * time.Minute),
+	}
+
+	_, err := creds.AuthorizationHeader()
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "auth login") {
+		t.Errorf("Expected error to suggest `auth login`, got: %v", err)
+	}
+}
+
+func TestOAuthCredentials_AuthorizationHeader_RefreshFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error": "invalid_grant"}`))
+	}))
+	defer server.Close()
+
+	creds := &OAuthCredentials{
+		AccessToken:  "expiredtoken",
+		RefreshToken: "expiredrefresh",
+		Expiry:       time.Now().Add(-1 * time.Minute),
+		ClientID:     "myclient",
+		OAuth:        &OAuthClient{subdomain: "test", baseURLOverride: server.URL},
+	}
+
+	_, err := creds.AuthorizationHeader()
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "auth login") {
+		t.Errorf("Expected error to suggest `auth login`, got: %v", err)
+	}
+}
+
+func TestClientCredentialsProvider_FetchesAndCachesToken(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token": "citoken",
+			"token_type": "bearer",
+			"expires_in": 1800
+		}`))
+	}))
+	defer server.Close()
+
+	provider := &ClientCredentialsProvider{
+		ClientID:     "ciclient",
+		ClientSecret: "cisecret",
+		Scope:        "hc:read hc:write",
+		OAuth:        &OAuthClient{subdomain: "test", baseURLOverride: server.URL},
+	}
+
+	for i := 0; i < 3; i++ {
+		authz, err := provider.AuthorizationHeader()
+		if err != nil {
+			t.Fatalf("AuthorizationHeader() error = %v", err)
+		}
+		if authz != "Bearer citoken" {
+			t.Errorf("AuthorizationHeader() = %s, want Bearer citoken", authz)
+		}
+	}
+
+	if got := requests.Load(); got != 1 {
+		t.Errorf("Expected 1 token request (cached afterwards), got %d", got)
+	}
+}
+
+func TestClientCredentialsProvider_RefetchesExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token": "citoken",
+			"token_type": "bearer",
+			"expires_in": 1800
+		}`))
+	}))
+	defer server.Close()
+
+	provider := &ClientCredentialsProvider{
+		ClientID:     "ciclient",
+		ClientSecret: "cisecret",
+		OAuth:        &OAuthClient{subdomain: "test", baseURLOverride: server.URL},
+	}
+
+	if _, err := provider.AuthorizationHeader(); err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
+	provider.expiry = time.Now().Add(-1 * time.Second)
+	if _, err := provider.AuthorizationHeader(); err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
+
+	if got := requests.Load(); got != 2 {
+		t.Errorf("Expected 2 token requests after forced expiry, got %d", got)
+	}
+}
+
+func TestClientCredentialsProvider_ShortLivedTokenIsNotThrashResistant(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		// Shorter than the expiry margin; the clamped margin must still leave
+		// the token usable so consecutive requests do not refetch every time.
+		_, _ = w.Write([]byte(`{
+			"access_token": "citoken",
+			"token_type": "bearer",
+			"expires_in": 10
+		}`))
+	}))
+	defer server.Close()
+
+	provider := &ClientCredentialsProvider{
+		ClientID:     "ciclient",
+		ClientSecret: "cisecret",
+		OAuth:        &OAuthClient{subdomain: "test", baseURLOverride: server.URL},
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := provider.AuthorizationHeader(); err != nil {
+			t.Fatalf("AuthorizationHeader() error = %v", err)
+		}
+	}
+
+	if got := requests.Load(); got != 1 {
+		t.Errorf("Expected 1 token request for consecutive calls within the clamped margin, got %d", got)
+	}
+}
+
+// invalidatingCreds is a fake credential that switches to a fresh token when
+// the client invalidates it after a 401.
+type invalidatingCreds struct {
+	header      string
+	invalidated int
+}
+
+func (f *invalidatingCreds) AuthorizationHeader() (string, error) { return f.header, nil }
+func (f *invalidatingCreds) Invalidate() {
+	f.invalidated++
+	f.header = "Bearer fresh"
+}
+
+func TestClient_401InvalidatesTokenAndRetriesOnce(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer fresh" {
+			t.Errorf("retry did not use the refreshed token: %s", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"article": {}}`))
+	}))
+	defer server.Close()
+
+	creds := &invalidatingCreds{header: "Bearer stale"}
+	client := &clientImpl{subdomain: "test", creds: creds, baseURLOverride: server.URL}
+
+	if _, err := client.ShowArticle("en_us", 123); err != nil {
+		t.Fatalf("ShowArticle() error = %v", err)
+	}
+	if creds.invalidated != 1 {
+		t.Errorf("Invalidate called %d times, want 1", creds.invalidated)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Errorf("Expected 2 requests (401 then retry), got %d", got)
+	}
+}
+
+func TestClient_401WithoutInvalidatorFailsImmediately(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := &clientImpl{
+		subdomain:       "test",
+		creds:           &TokenCredentials{Email: "user@example.com/token", Token: "t"},
+		baseURLOverride: server.URL,
+	}
+
+	_, err := client.ShowArticle("en_us", 123)
+	if err == nil || !strings.Contains(err.Error(), "401") {
+		t.Fatalf("Expected 401 error, got: %v", err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Errorf("Expected 1 request (no retry for Basic auth), got %d", got)
+	}
+}
+
+func TestClientCredentialsProvider_TokenRequestFailure(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error": "invalid_client"}`))
+	}))
+	defer server.Close()
+
+	provider := &ClientCredentialsProvider{
+		ClientID:     "ciclient",
+		ClientSecret: "wrongsecret",
+		OAuth:        &OAuthClient{subdomain: "test", baseURLOverride: server.URL},
+	}
+
+	_, err := provider.AuthorizationHeader()
+	if err == nil {
+		t.Fatal("Expected error but got none")
+	}
+	if !strings.Contains(err.Error(), "status 401") {
+		t.Errorf("Expected error containing 'status 401', got: %v", err)
+	}
+}

--- a/internal/zendesk/credentials_test.go
+++ b/internal/zendesk/credentials_test.go
@@ -301,6 +301,93 @@ func TestClient_401WithoutInvalidatorFailsImmediately(t *testing.T) {
 	}
 }
 
+// TestClient_401RefreshesOAuthTokenAndRetries exercises the whole self-healing
+// flow with a real OAuthCredentials: a token that is valid locally but revoked
+// server-side gets a 401, is invalidated, refreshed, and the request is retried.
+func TestClient_401RefreshesOAuthTokenAndRetries(t *testing.T) {
+	t.Parallel()
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token": "fresh",
+			"refresh_token": "newrefresh",
+			"token_type": "bearer",
+			"expires_in": 1800
+		}`))
+	}))
+	defer tokenServer.Close()
+
+	var apiRequests atomic.Int32
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if apiRequests.Add(1) == 1 {
+			if got := r.Header.Get("Authorization"); got != "Bearer stale" {
+				t.Errorf("first request Authorization = %s, want Bearer stale", got)
+			}
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer fresh" {
+			t.Errorf("retry Authorization = %s, want Bearer fresh", got)
+		}
+		_, _ = w.Write([]byte(`{"article": {}}`))
+	}))
+	defer apiServer.Close()
+
+	creds := &OAuthCredentials{
+		AccessToken:  "stale",
+		RefreshToken: "refreshtoken",
+		Expiry:       time.Now().Add(1 * time.Hour), // locally valid, revoked server-side
+		ClientID:     "myclient",
+		OAuth:        &OAuthClient{subdomain: "test", baseURLOverride: tokenServer.URL},
+	}
+	client := &clientImpl{subdomain: "test", creds: creds, baseURLOverride: apiServer.URL}
+
+	if _, err := client.ShowArticle("en_us", 123); err != nil {
+		t.Fatalf("ShowArticle() error = %v", err)
+	}
+	if got := apiRequests.Load(); got != 2 {
+		t.Errorf("Expected 2 API requests (401 then retry), got %d", got)
+	}
+	if creds.AccessToken != "fresh" || creds.RefreshToken != "newrefresh" {
+		t.Errorf("credentials after retry = (%s, %s), want (fresh, newrefresh)", creds.AccessToken, creds.RefreshToken)
+	}
+}
+
+func TestClientCredentialsProvider_InvalidateForcesRefetch(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"access_token": "citoken",
+			"token_type": "bearer",
+			"expires_in": 1800
+		}`))
+	}))
+	defer server.Close()
+
+	provider := &ClientCredentialsProvider{
+		ClientID:     "ciclient",
+		ClientSecret: "cisecret",
+		OAuth:        &OAuthClient{subdomain: "test", baseURLOverride: server.URL},
+	}
+
+	if _, err := provider.AuthorizationHeader(); err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
+	provider.Invalidate()
+	if _, err := provider.AuthorizationHeader(); err != nil {
+		t.Fatalf("AuthorizationHeader() error = %v", err)
+	}
+
+	if got := requests.Load(); got != 2 {
+		t.Errorf("Expected 2 token requests after Invalidate, got %d", got)
+	}
+}
+
 func TestClientCredentialsProvider_TokenRequestFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/zendesk/credentials_test.go
+++ b/internal/zendesk/credentials_test.go
@@ -9,6 +9,16 @@ import (
 	"time"
 )
 
+// closedServerURL returns the URL of a server that is immediately closed,
+// so any HTTP request to it will fail with a connection error.
+func closedServerURL(t *testing.T) string {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	u := s.URL
+	s.Close()
+	return u
+}
+
 func TestOAuthCredentials_AuthorizationHeader_ValidToken(t *testing.T) {
 	t.Parallel()
 
@@ -385,6 +395,21 @@ func TestClientCredentialsProvider_InvalidateForcesRefetch(t *testing.T) {
 
 	if got := requests.Load(); got != 2 {
 		t.Errorf("Expected 2 token requests after Invalidate, got %d", got)
+	}
+}
+
+func TestClient_AttemptNetworkError(t *testing.T) {
+	t.Parallel()
+
+	client := &clientImpl{
+		subdomain:       "test",
+		creds:           &TokenCredentials{Email: "user@example.com/token", Token: "t"},
+		baseURLOverride: closedServerURL(t),
+	}
+
+	_, err := client.ShowArticle("en_us", 123)
+	if err == nil {
+		t.Fatal("Expected network error but got none")
 	}
 }
 

--- a/internal/zendesk/oauth.go
+++ b/internal/zendesk/oauth.go
@@ -1,0 +1,128 @@
+package zendesk
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// OAuthTokenResponse is the response body of POST /oauth/tokens.
+// refs: https://developer.zendesk.com/api-reference/ticketing/oauth/oauth_tokens/
+type OAuthTokenResponse struct {
+	AccessToken           string `json:"access_token"`
+	RefreshToken          string `json:"refresh_token"`
+	TokenType             string `json:"token_type"`
+	Scope                 string `json:"scope"`
+	ExpiresIn             int    `json:"expires_in"`
+	RefreshTokenExpiresIn int    `json:"refresh_token_expires_in"`
+}
+
+// ExpiryTime converts ExpiresIn into an absolute expiry with a safety margin
+// applied, clamped to half the lifetime so short-lived tokens remain usable
+// after being issued. A zero return value means the token does not expire.
+func (r *OAuthTokenResponse) ExpiryTime() time.Time {
+	if r.ExpiresIn <= 0 {
+		return time.Time{}
+	}
+	lifetime := time.Duration(r.ExpiresIn) * time.Second
+	margin := tokenExpiryMargin
+	if half := lifetime / 2; half < margin {
+		margin = half
+	}
+	return time.Now().Add(lifetime - margin)
+}
+
+// OAuthClient issues token requests against the Zendesk OAuth token endpoint.
+type OAuthClient struct {
+	subdomain       string
+	baseURLOverride string
+}
+
+func NewOAuthClient(subdomain string) *OAuthClient {
+	return &OAuthClient{subdomain: subdomain}
+}
+
+// NewOAuthClientWithBaseURL creates an OAuthClient that sends requests to baseURL
+// instead of the Zendesk endpoint. Intended for tests.
+func NewOAuthClientWithBaseURL(subdomain, baseURL string) *OAuthClient {
+	return &OAuthClient{subdomain: subdomain, baseURLOverride: baseURL}
+}
+
+// ExchangeAuthorizationCode exchanges an authorization code for tokens using PKCE.
+// refs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/#creating-authorization-code-grant-type-tokens
+func (o *OAuthClient) ExchangeAuthorizationCode(clientID, code, redirectURI, codeVerifier string) (*OAuthTokenResponse, error) {
+	return o.doTokenRequest(map[string]string{
+		"grant_type":    "authorization_code",
+		"code":          code,
+		"client_id":     clientID,
+		"redirect_uri":  redirectURI,
+		"code_verifier": codeVerifier,
+	})
+}
+
+// RefreshToken obtains a new access token using a refresh token.
+// refs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/#creating-refresh-token-grant-type-tokens
+func (o *OAuthClient) RefreshToken(clientID, refreshToken string) (*OAuthTokenResponse, error) {
+	return o.doTokenRequest(map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": refreshToken,
+		"client_id":     clientID,
+	})
+}
+
+// ClientCredentials obtains an access token using the client_credentials grant.
+// The token user is the owner of the OAuth client.
+// refs: https://developer.zendesk.com/api-reference/ticketing/oauth/grant_type_tokens/#creating-client-credentials-grant-type-tokens
+func (o *OAuthClient) ClientCredentials(clientID, clientSecret, scope string) (*OAuthTokenResponse, error) {
+	return o.doTokenRequest(map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     clientID,
+		"client_secret": clientSecret,
+		"scope":         scope,
+	})
+}
+
+func (o *OAuthClient) doTokenRequest(params map[string]string) (*OAuthTokenResponse, error) {
+	body, err := json.Marshal(params)
+	if err != nil {
+		return nil, err
+	}
+
+	reqURL := o.baseURL() + "/oauth/tokens"
+	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("token request failed with status %d: %s", res.StatusCode, string(resBody))
+	}
+
+	token := &OAuthTokenResponse{}
+	if err := json.Unmarshal(resBody, token); err != nil {
+		return nil, err
+	}
+	if token.AccessToken == "" {
+		return nil, fmt.Errorf("token response does not contain an access token")
+	}
+	return token, nil
+}
+
+func (o *OAuthClient) baseURL() string {
+	return resolveBaseURL(o.subdomain, o.baseURLOverride)
+}

--- a/internal/zendesk/oauth_test.go
+++ b/internal/zendesk/oauth_test.go
@@ -166,6 +166,14 @@ func TestOAuthClient_TokenRequestErrors(t *testing.T) {
 			response:      `{"token_type": "bearer"}`,
 			errorContains: "does not contain an access token",
 		},
+		{
+			// Defensive path for a Zendesk-side bug; unlikely in practice
+			// but the branch must not panic.
+			name:          "malformed JSON in 200 response",
+			status:        http.StatusOK,
+			response:      `{not valid json`,
+			errorContains: "invalid",
+		},
 	}
 
 	for _, tt := range tests {
@@ -230,6 +238,21 @@ func TestOAuthTokenResponse_ExpiryTime(t *testing.T) {
 		res := &OAuthTokenResponse{ExpiresIn: 10}
 		within(t, res.ExpiryTime(), time.Now().Add(5*time.Second), 2*time.Second)
 	})
+}
+
+// TestNewOAuthClientWithBaseURL exists to keep the function covered in the
+// zendesk package's own test binary. The function is only called from cli
+// package tests, which do not instrument zendesk package code.
+func TestNewOAuthClientWithBaseURL(t *testing.T) {
+	t.Parallel()
+
+	client := NewOAuthClientWithBaseURL("mycompany", "http://example.com")
+	if client.subdomain != "mycompany" || client.baseURLOverride != "http://example.com" {
+		t.Errorf("NewOAuthClientWithBaseURL() = %+v", client)
+	}
+	if got := client.baseURL(); got != "http://example.com" {
+		t.Errorf("baseURL() = %s, want http://example.com", got)
+	}
 }
 
 func TestOAuthClient_BaseURL(t *testing.T) {

--- a/internal/zendesk/oauth_test.go
+++ b/internal/zendesk/oauth_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newOAuthTestServer(t *testing.T, wantParams map[string]string, response string, status int) *httptest.Server {
@@ -185,6 +186,50 @@ func TestOAuthClient_TokenRequestErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOAuthTokenResponse_ExpiryTime(t *testing.T) {
+	t.Parallel()
+
+	// within asserts got is in [want-tolerance, want+tolerance].
+	within := func(t *testing.T, got, want time.Time, tolerance time.Duration) {
+		t.Helper()
+		if got.Before(want.Add(-tolerance)) || got.After(want.Add(tolerance)) {
+			t.Errorf("ExpiryTime() = %v, want %v +/- %v", got, want, tolerance)
+		}
+	}
+
+	t.Run("zero expires_in means no expiry", func(t *testing.T) {
+		t.Parallel()
+
+		res := &OAuthTokenResponse{ExpiresIn: 0}
+		if got := res.ExpiryTime(); !got.IsZero() {
+			t.Errorf("ExpiryTime() = %v, want zero time", got)
+		}
+	})
+
+	t.Run("negative expires_in means no expiry", func(t *testing.T) {
+		t.Parallel()
+
+		res := &OAuthTokenResponse{ExpiresIn: -1}
+		if got := res.ExpiryTime(); !got.IsZero() {
+			t.Errorf("ExpiryTime() = %v, want zero time", got)
+		}
+	})
+
+	t.Run("margin is subtracted from the lifetime", func(t *testing.T) {
+		t.Parallel()
+
+		res := &OAuthTokenResponse{ExpiresIn: 1800}
+		within(t, res.ExpiryTime(), time.Now().Add(1800*time.Second-tokenExpiryMargin), 2*time.Second)
+	})
+
+	t.Run("margin is clamped to half the lifetime for short-lived tokens", func(t *testing.T) {
+		t.Parallel()
+
+		res := &OAuthTokenResponse{ExpiresIn: 10}
+		within(t, res.ExpiryTime(), time.Now().Add(5*time.Second), 2*time.Second)
+	})
 }
 
 func TestOAuthClient_BaseURL(t *testing.T) {

--- a/internal/zendesk/oauth_test.go
+++ b/internal/zendesk/oauth_test.go
@@ -1,0 +1,198 @@
+package zendesk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newOAuthTestServer(t *testing.T, wantParams map[string]string, response string, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Expected POST method, got %s", r.Method)
+		}
+		if r.URL.Path != "/oauth/tokens" {
+			t.Errorf("Expected path /oauth/tokens, got %s", r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Expected Content-Type application/json, got %s", ct)
+		}
+
+		var params map[string]string
+		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
+			t.Errorf("Failed to decode request body: %v", err)
+		}
+		for k, want := range wantParams {
+			if got := params[k]; got != want {
+				t.Errorf("Expected param %s=%s, got %s", k, want, got)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(response))
+	}))
+}
+
+func TestOAuthClient_ExchangeAuthorizationCode(t *testing.T) {
+	t.Parallel()
+
+	response := `{
+		"access_token": "access123",
+		"refresh_token": "refresh456",
+		"token_type": "bearer",
+		"scope": "hc:read hc:write",
+		"expires_in": 1800,
+		"refresh_token_expires_in": 2592000
+	}`
+	server := newOAuthTestServer(t, map[string]string{
+		"grant_type":    "authorization_code",
+		"code":          "authcode",
+		"client_id":     "myclient",
+		"redirect_uri":  "http://127.0.0.1:8080/callback",
+		"code_verifier": "verifier123",
+	}, response, http.StatusOK)
+	defer server.Close()
+
+	client := &OAuthClient{subdomain: "test", baseURLOverride: server.URL}
+	token, err := client.ExchangeAuthorizationCode("myclient", "authcode", "http://127.0.0.1:8080/callback", "verifier123")
+	if err != nil {
+		t.Fatalf("ExchangeAuthorizationCode() error = %v", err)
+	}
+
+	if token.AccessToken != "access123" {
+		t.Errorf("AccessToken = %s, want access123", token.AccessToken)
+	}
+	if token.RefreshToken != "refresh456" {
+		t.Errorf("RefreshToken = %s, want refresh456", token.RefreshToken)
+	}
+	if token.ExpiresIn != 1800 {
+		t.Errorf("ExpiresIn = %d, want 1800", token.ExpiresIn)
+	}
+	if token.RefreshTokenExpiresIn != 2592000 {
+		t.Errorf("RefreshTokenExpiresIn = %d, want 2592000", token.RefreshTokenExpiresIn)
+	}
+}
+
+func TestOAuthClient_RefreshToken(t *testing.T) {
+	t.Parallel()
+
+	response := `{
+		"access_token": "newaccess",
+		"refresh_token": "newrefresh",
+		"token_type": "bearer",
+		"expires_in": 1800
+	}`
+	server := newOAuthTestServer(t, map[string]string{
+		"grant_type":    "refresh_token",
+		"refresh_token": "oldrefresh",
+		"client_id":     "myclient",
+	}, response, http.StatusOK)
+	defer server.Close()
+
+	client := &OAuthClient{subdomain: "test", baseURLOverride: server.URL}
+	token, err := client.RefreshToken("myclient", "oldrefresh")
+	if err != nil {
+		t.Fatalf("RefreshToken() error = %v", err)
+	}
+
+	if token.AccessToken != "newaccess" {
+		t.Errorf("AccessToken = %s, want newaccess", token.AccessToken)
+	}
+	if token.RefreshToken != "newrefresh" {
+		t.Errorf("RefreshToken = %s, want newrefresh", token.RefreshToken)
+	}
+}
+
+func TestOAuthClient_ClientCredentials(t *testing.T) {
+	t.Parallel()
+
+	response := `{
+		"access_token": "ciaccess",
+		"token_type": "bearer",
+		"scope": "hc:read hc:write",
+		"expires_in": 1800
+	}`
+	server := newOAuthTestServer(t, map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     "ciclient",
+		"client_secret": "cisecret",
+		"scope":         "hc:read hc:write",
+	}, response, http.StatusOK)
+	defer server.Close()
+
+	client := &OAuthClient{subdomain: "test", baseURLOverride: server.URL}
+	token, err := client.ClientCredentials("ciclient", "cisecret", "hc:read hc:write")
+	if err != nil {
+		t.Fatalf("ClientCredentials() error = %v", err)
+	}
+
+	if token.AccessToken != "ciaccess" {
+		t.Errorf("AccessToken = %s, want ciaccess", token.AccessToken)
+	}
+	if token.RefreshToken != "" {
+		t.Errorf("RefreshToken = %s, want empty", token.RefreshToken)
+	}
+}
+
+func TestOAuthClient_TokenRequestErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		status        int
+		response      string
+		errorContains string
+	}{
+		{
+			name:          "invalid grant returns 400",
+			status:        http.StatusBadRequest,
+			response:      `{"error": "invalid_grant", "error_description": "authorization code is invalid or expired"}`,
+			errorContains: "status 400",
+		},
+		{
+			name:          "unauthorized client returns 401",
+			status:        http.StatusUnauthorized,
+			response:      `{"error": "invalid_client"}`,
+			errorContains: "status 401",
+		},
+		{
+			name:          "missing access token in response",
+			status:        http.StatusOK,
+			response:      `{"token_type": "bearer"}`,
+			errorContains: "does not contain an access token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newOAuthTestServer(t, nil, tt.response, tt.status)
+			defer server.Close()
+
+			client := &OAuthClient{subdomain: "test", baseURLOverride: server.URL}
+			_, err := client.RefreshToken("myclient", "refresh")
+
+			if err == nil {
+				t.Fatal("Expected error but got none")
+			}
+			if !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("Expected error containing %q, got: %v", tt.errorContains, err)
+			}
+		})
+	}
+}
+
+func TestOAuthClient_BaseURL(t *testing.T) {
+	t.Parallel()
+
+	client := NewOAuthClient("mycompany")
+	expected := "https://mycompany.zendesk.com"
+	if got := client.baseURL(); got != expected {
+		t.Errorf("baseURL() = %s, want %s", got, expected)
+	}
+}


### PR DESCRIPTION
## Summary

- Add OAuth authentication in preparation for [Zendesk's announced removal of API tokens as an authentication method for API requests](https://support.zendesk.com/hc/en-us/articles/10851263566234-Announcing-the-removal-of-API-tokens-as-an-authentication-method-for-API-requests): authorization code grant with PKCE for interactive use, and client_credentials grant for CI
- Add a `zgsync auth login` command that opens the browser, receives the authorization callback on a local server, and saves tokens per subdomain to `~/.config/zgsync/credentials.json`
- Expired access tokens are refreshed automatically and re-persisted; a 401 response invalidates the cached token and retries the request once

## Changes

### zendesk package

- Introduce a `Credentials` interface that provides the `Authorization` header, with three implementations: `TokenCredentials` (existing Basic auth), `OAuthCredentials` (Bearer token with automatic refresh and an `OnRefresh` persistence hook), and `ClientCredentialsProvider` (fetches on demand, caches in memory)
- Add `OAuthClient` for `POST /oauth/tokens` supporting the authorization_code (PKCE), refresh_token, and client_credentials grants
- The API client now shares a single `http.Client` with a 30s timeout, and on a 401 invalidates the cached token and retries once so a server-side revoked token self-heals

### cli package

- New config fields: `auth_type` (`token` (default) / `oauth` / `client_credentials`), `oauth_client_id`, and `oauth_scope`. The client secret is accepted only via the `ZGSYNC_OAUTH_CLIENT_SECRET` environment variable and never read from the config file
- `auth login` runs a local callback server with state verification and PKCE, and stores tokens with 0600 permissions using atomic writes
- `LoadConfig` now fails on a missing or unreadable config file instead of silently running with a zero-value config; `auth login` uses a lenient loader that only requires `subdomain` so users migrating to OAuth can log in without an API token

### Docs & tests

- README and CLAUDE.md document the OAuth setup
- Tests cover the login flow (success, denied, state mismatch, stray requests, timeout), token refresh and persistence, the 401 self-healing retry, credential store atomicity and permissions, and config validation per auth type